### PR TITLE
Eliminate pure/elemental key words for vapor saturation related subroutines, add the vectorized versions of subroutines and change the interface for GPU computation

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -37,7 +37,7 @@ required = True
 local_path = src/physics/pumas
 protocol = git
 repo_url = https://github.com/ESCOMP/PUMAS
-tag = pumas_cam-release_v1.8
+tag = pumas_cam-release_v1.9
 required = True
 
 [atmos_phys]

--- a/src/chemistry/bulk_aero/seasalt_model.F90
+++ b/src/chemistry/bulk_aero/seasalt_model.F90
@@ -108,7 +108,11 @@ module seasalt_model
 
     !-----------------------------------------------------------------------
 
-    call qsat(temp(:ncol,:),pmid(:ncol,:),es(:ncol,:),qs(:ncol,:))
+    do k = 1, pver
+       do i = 1, ncol
+          call qsat(temp(i,k),pmid(i,k),es(i,k),qs(i,k))
+       end do
+    end do
     RH(:ncol,:)=q(:ncol,:)/qs(:ncol,:)
     RH(:ncol,:)=max(0.01_r8,min(0.99_r8,RH(:ncol,:)))
     ! set stokes correction to 1.0 for now not a bad assumption for our size range)

--- a/src/chemistry/bulk_aero/seasalt_model.F90
+++ b/src/chemistry/bulk_aero/seasalt_model.F90
@@ -107,8 +107,9 @@ module seasalt_model
     real(r8), parameter :: sslt_smt_vwr(seasalt_nbin) = (/0.52e-6_r8,2.38e-6_r8,4.86e-6_r8,15.14e-6_r8/) 
 
     !-----------------------------------------------------------------------
-
-    call qsat(temp(1:ncol,1:pver),pmid(1:ncol,1:pver),es(1:ncol,1:pver),qs(1:ncol,1:pver),ncol,pver)
+    do k = 1, pver
+       call qsat(temp(1:ncol,k),pmid(1:ncol,k),es(1:ncol,k),qs(1:ncol,k),ncol)
+    end do
     RH(:ncol,:)=q(:ncol,:)/qs(:ncol,:)
     RH(:ncol,:)=max(0.01_r8,min(0.99_r8,RH(:ncol,:)))
     ! set stokes correction to 1.0 for now not a bad assumption for our size range)

--- a/src/chemistry/bulk_aero/seasalt_model.F90
+++ b/src/chemistry/bulk_aero/seasalt_model.F90
@@ -108,9 +108,7 @@ module seasalt_model
 
     !-----------------------------------------------------------------------
 
-    do k = 1, pver
-       call qsat(temp(1:ncol,k),pmid(1:ncol,k),es(1:ncol,k),qs(1:ncol,k),ncol)
-    end do
+    call qsat(temp(1:ncol,1:pver),pmid(1:ncol,1:pver),es(1:ncol,1:pver),qs(1:ncol,1:pver),ncol,pver)
     RH(:ncol,:)=q(:ncol,:)/qs(:ncol,:)
     RH(:ncol,:)=max(0.01_r8,min(0.99_r8,RH(:ncol,:)))
     ! set stokes correction to 1.0 for now not a bad assumption for our size range)

--- a/src/chemistry/bulk_aero/seasalt_model.F90
+++ b/src/chemistry/bulk_aero/seasalt_model.F90
@@ -109,9 +109,7 @@ module seasalt_model
     !-----------------------------------------------------------------------
 
     do k = 1, pver
-       do i = 1, ncol
-          call qsat(temp(i,k),pmid(i,k),es(i,k),qs(i,k))
-       end do
+       call qsat(temp(1:ncol,k),pmid(1:ncol,k),es(1:ncol,k),qs(1:ncol,k),ncol)
     end do
     RH(:ncol,:)=q(:ncol,:)/qs(:ncol,:)
     RH(:ncol,:)=max(0.01_r8,min(0.99_r8,RH(:ncol,:)))

--- a/src/chemistry/modal_aero/modal_aero_newnuc.F90
+++ b/src/chemistry/modal_aero/modal_aero_newnuc.F90
@@ -237,9 +237,11 @@ module modal_aero_newnuc
 	mass1p_aithi = tmpa*(dphim_mode(1)**3)
 
 !   compute qv_sat = saturation specific humidity
-	call qsat(t(1:ncol, 1:pver), pmid(1:ncol, 1:pver), &
-            ev_sat(1:ncol, 1:pver), qv_sat(1:ncol, 1:pver))
-
+        do k = 1, pver
+           do i = 1, ncol
+	      call qsat(t(i,k), pmid(i,k), ev_sat(i,k), qv_sat(i,k))
+           end do
+        end do
 
 !
 !   loop over levels and columns to calc the renaming

--- a/src/chemistry/modal_aero/modal_aero_newnuc.F90
+++ b/src/chemistry/modal_aero/modal_aero_newnuc.F90
@@ -238,9 +238,7 @@ module modal_aero_newnuc
 
 !   compute qv_sat = saturation specific humidity
         do k = 1, pver
-           do i = 1, ncol
-	      call qsat(t(i,k), pmid(i,k), ev_sat(i,k), qv_sat(i,k))
-           end do
+	   call qsat(t(1:ncol,k), pmid(1:ncol,k), ev_sat(1:ncol,k), qv_sat(1:ncol,k), ncol)
         end do
 
 !

--- a/src/chemistry/modal_aero/modal_aero_newnuc.F90
+++ b/src/chemistry/modal_aero/modal_aero_newnuc.F90
@@ -237,9 +237,7 @@ module modal_aero_newnuc
 	mass1p_aithi = tmpa*(dphim_mode(1)**3)
 
 !   compute qv_sat = saturation specific humidity
-        do k = 1, pver
-	   call qsat(t(1:ncol,k), pmid(1:ncol,k), ev_sat(1:ncol,k), qv_sat(1:ncol,k), ncol)
-        end do
+	call qsat(t(1:ncol,1:pver), pmid(1:ncol,1:pver), ev_sat(1:ncol,1:pver), qv_sat(1:ncol,1:pver), ncol, pver)
 
 !
 !   loop over levels and columns to calc the renaming

--- a/src/chemistry/modal_aero/modal_aero_newnuc.F90
+++ b/src/chemistry/modal_aero/modal_aero_newnuc.F90
@@ -237,8 +237,9 @@ module modal_aero_newnuc
 	mass1p_aithi = tmpa*(dphim_mode(1)**3)
 
 !   compute qv_sat = saturation specific humidity
-	call qsat(t(1:ncol,1:pver), pmid(1:ncol,1:pver), ev_sat(1:ncol,1:pver), qv_sat(1:ncol,1:pver), ncol, pver)
-
+        do k = 1, pver
+	   call qsat(t(1:ncol,k), pmid(1:ncol,k), ev_sat(1:ncol,k), qv_sat(1:ncol,k), ncol)
+        end do
 !
 !   loop over levels and columns to calc the renaming
 !

--- a/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -740,7 +740,11 @@ contains
     !-----------------------------------------------------------------
     !	... compute the relative humidity
     !-----------------------------------------------------------------
-    call qsat(tfld(:ncol,:), pmid(:ncol,:), satv, satq)
+    do k = 1, pver
+       do i = 1, ncol
+          call qsat(tfld(i,k), pmid(i,k), satv(i,k), satq(i,k))
+       end do
+    end do
 
     do k = 1,pver
        relhum(:,k) = .622_r8 * h2ovmr(:,k) / satq(:,k)

--- a/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -741,9 +741,7 @@ contains
     !	... compute the relative humidity
     !-----------------------------------------------------------------
     do k = 1, pver
-       do i = 1, ncol
-          call qsat(tfld(i,k), pmid(i,k), satv(i,k), satq(i,k))
-       end do
+       call qsat(tfld(1:ncol,k), pmid(1:ncol,k), satv(1:ncol,k), satq(1:ncol,k), ncol)
     end do
 
     do k = 1,pver

--- a/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -740,9 +740,7 @@ contains
     !-----------------------------------------------------------------
     !	... compute the relative humidity
     !-----------------------------------------------------------------
-    do k = 1, pver
-       call qsat(tfld(1:ncol,k), pmid(1:ncol,k), satv(1:ncol,k), satq(1:ncol,k), ncol)
-    end do
+    call qsat(tfld(1:ncol,1:pver), pmid(1:ncol,1:pver), satv(1:ncol,1:pver), satq(1:ncol,1:pver), ncol, pver)
 
     do k = 1,pver
        relhum(:,k) = .622_r8 * h2ovmr(:,k) / satq(:,k)

--- a/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -740,7 +740,9 @@ contains
     !-----------------------------------------------------------------
     !	... compute the relative humidity
     !-----------------------------------------------------------------
-    call qsat(tfld(1:ncol,1:pver), pmid(1:ncol,1:pver), satv(1:ncol,1:pver), satq(1:ncol,1:pver), ncol, pver)
+    do k = 1, pver
+       call qsat(tfld(1:ncol,k), pmid(1:ncol,k), satv(1:ncol,k), satq(1:ncol,k), ncol)
+    end do
 
     do k = 1,pver
        relhum(:,k) = .622_r8 * h2ovmr(:,k) / satq(:,k)

--- a/src/chemistry/utils/modal_aero_wateruptake.F90
+++ b/src/chemistry/utils/modal_aero_wateruptake.F90
@@ -393,8 +393,8 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    call pbuf_get_field(pbuf, cld_idx, cldn, start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
 
    do k = top_lev, pver
-      call qsat_water(t(:ncol,k), pmid(:ncol,k), es(:ncol), qs(:ncol))
       do i = 1, ncol
+         call qsat_water(t(i,k), pmid(i,k), es(i), qs(i))
          if (qs(i) > h2ommr(i,k)) then
             rh(i,k) = h2ommr(i,k)/qs(i)
          else

--- a/src/chemistry/utils/modal_aero_wateruptake.F90
+++ b/src/chemistry/utils/modal_aero_wateruptake.F90
@@ -393,8 +393,8 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    call pbuf_get_field(pbuf, cld_idx, cldn, start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
 
    do k = top_lev, pver
+      call qsat_water(t(1:ncol,k), pmid(1:ncol,k), es(1:ncol), qs(1:ncol), ncol)
       do i = 1, ncol
-         call qsat_water(t(i,k), pmid(i,k), es(i), qs(i))
          if (qs(i) > h2ommr(i,k)) then
             rh(i,k) = h2ommr(i,k)/qs(i)
          else

--- a/src/chemistry/utils/modal_aero_wateruptake.F90
+++ b/src/chemistry/utils/modal_aero_wateruptake.F90
@@ -230,8 +230,8 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    real(r8) :: rh(pcols,pver)        ! relative humidity (0-1)
    real(r8) :: dmean, qh2so4_equilib, wtpct_mode, sulden_mode
 
-   real(r8) :: es(pcols)             ! saturation vapor pressure
-   real(r8) :: qs(pcols)             ! saturation specific humidity
+   real(r8) :: es(pcols,pver)        ! saturation vapor pressure
+   real(r8) :: qs(pcols,pver)        ! saturation specific humidity
 
    real(r8) :: pm25(pcols,pver)      ! PM2.5 diagnostics     
    real(r8) :: rhoair(pcols,pver) 
@@ -392,11 +392,11 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    itim_old    =  pbuf_old_tim_idx()
    call pbuf_get_field(pbuf, cld_idx, cldn, start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
 
+   call qsat_water(t(1:ncol,top_lev:pver), pmid(1:ncol,top_lev:pver), es(1:ncol,top_lev:pver), qs(1:ncol,top_lev:pver), ncol, pver-top_lev+1)
    do k = top_lev, pver
-      call qsat_water(t(1:ncol,k), pmid(1:ncol,k), es(1:ncol), qs(1:ncol), ncol)
       do i = 1, ncol
-         if (qs(i) > h2ommr(i,k)) then
-            rh(i,k) = h2ommr(i,k)/qs(i)
+         if (qs(i,k) > h2ommr(i,k)) then
+            rh(i,k) = h2ommr(i,k)/qs(i,k)
          else
             rh(i,k) = 0.98_r8
          endif

--- a/src/chemistry/utils/modal_aero_wateruptake.F90
+++ b/src/chemistry/utils/modal_aero_wateruptake.F90
@@ -230,8 +230,8 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    real(r8) :: rh(pcols,pver)        ! relative humidity (0-1)
    real(r8) :: dmean, qh2so4_equilib, wtpct_mode, sulden_mode
 
-   real(r8) :: es(pcols,pver)        ! saturation vapor pressure
-   real(r8) :: qs(pcols,pver)        ! saturation specific humidity
+   real(r8) :: es(pcols)             ! saturation vapor pressure
+   real(r8) :: qs(pcols)             ! saturation specific humidity
 
    real(r8) :: pm25(pcols,pver)      ! PM2.5 diagnostics     
    real(r8) :: rhoair(pcols,pver) 
@@ -392,11 +392,11 @@ subroutine modal_aero_wateruptake_dr(state, pbuf, list_idx_in, dgnumdry_m, dgnum
    itim_old    =  pbuf_old_tim_idx()
    call pbuf_get_field(pbuf, cld_idx, cldn, start=(/1,1,itim_old/), kount=(/pcols,pver,1/) )
 
-   call qsat_water(t(1:ncol,top_lev:pver), pmid(1:ncol,top_lev:pver), es(1:ncol,top_lev:pver), qs(1:ncol,top_lev:pver), ncol, pver-top_lev+1)
    do k = top_lev, pver
+      call qsat_water(t(1:ncol,k), pmid(1:ncol,k), es(1:ncol), qs(1:ncol), ncol)
       do i = 1, ncol
-         if (qs(i,k) > h2ommr(i,k)) then
-            rh(i,k) = h2ommr(i,k)/qs(i,k)
+         if (qs(i) > h2ommr(i,k)) then
+            rh(i,k) = h2ommr(i,k)/qs(i)
          else
             rh(i,k) = 0.98_r8
          endif

--- a/src/physics/cam/aer_rad_props.F90
+++ b/src/physics/cam/aer_rad_props.F90
@@ -132,7 +132,7 @@ subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, &
 
    integer :: ncol
    integer :: lchnk
-   integer :: k       ! index
+   integer :: i, k       ! index
    integer :: troplev(pcols)
 
    ! optical props for each aerosol
@@ -201,8 +201,11 @@ subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, &
    tau_w_f(1:ncol,:,:) = 0._r8
 
    ! calculate relative humidity for table lookup into rh grid
-   call qsat(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), &
-        es(1:ncol,1:pver), qs(1:ncol,1:pver))
+   do k = 1, pver
+      do i = 1, ncol
+         call qsat(state%t(i,k), state%pmid(i,k), es(i,k), qs(i,k))
+      end do
+   end do
    rh(1:ncol,1:pver) = state%q(1:ncol,1:pver,1) / qs(1:ncol,1:pver)
 
    rhtrunc(1:ncol,1:pver) = min(rh(1:ncol,1:pver),1._r8)
@@ -382,8 +385,11 @@ subroutine aer_rad_props_lw(list_idx, state, pbuf,  odap_aer)
       end do
 
       ! calculate relative humidity for table lookup into rh grid
-      call qsat(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), &
-           es(1:ncol,1:pver), qs(1:ncol,1:pver))
+      do k = 1, pver
+         do i = 1, ncol
+            call qsat(state%t(i,k), state%pmid(i,k), es(i,k), qs(i,k))
+         end do
+      end do
       rh(1:ncol,1:pver) = state%q(1:ncol,1:pver,1) / qs(1:ncol,1:pver)
 
       rhtrunc(1:ncol,1:pver) = min(rh(1:ncol,1:pver),1._r8)

--- a/src/physics/cam/aer_rad_props.F90
+++ b/src/physics/cam/aer_rad_props.F90
@@ -201,9 +201,7 @@ subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, &
    tau_w_f(1:ncol,:,:) = 0._r8
 
    ! calculate relative humidity for table lookup into rh grid
-   do k = 1, pver
-      call qsat(state%t(1:ncol,k), state%pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
-   end do
+   call qsat(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), es(1:ncol,1:pver), qs(1:ncol,1:pver), ncol, pver)
    rh(1:ncol,1:pver) = state%q(1:ncol,1:pver,1) / qs(1:ncol,1:pver)
 
    rhtrunc(1:ncol,1:pver) = min(rh(1:ncol,1:pver),1._r8)
@@ -383,9 +381,7 @@ subroutine aer_rad_props_lw(list_idx, state, pbuf,  odap_aer)
       end do
 
       ! calculate relative humidity for table lookup into rh grid
-      do k = 1, pver
-         call qsat(state%t(1:ncol,k), state%pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
-      end do
+      call qsat(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), es(1:ncol,1:pver), qs(1:ncol,1:pver), ncol, pver)
       rh(1:ncol,1:pver) = state%q(1:ncol,1:pver,1) / qs(1:ncol,1:pver)
 
       rhtrunc(1:ncol,1:pver) = min(rh(1:ncol,1:pver),1._r8)

--- a/src/physics/cam/aer_rad_props.F90
+++ b/src/physics/cam/aer_rad_props.F90
@@ -201,7 +201,9 @@ subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, &
    tau_w_f(1:ncol,:,:) = 0._r8
 
    ! calculate relative humidity for table lookup into rh grid
-   call qsat(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), es(1:ncol,1:pver), qs(1:ncol,1:pver), ncol, pver)
+   do k = 1, pver
+      call qsat(state%t(1:ncol,k), state%pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
+   end do
    rh(1:ncol,1:pver) = state%q(1:ncol,1:pver,1) / qs(1:ncol,1:pver)
 
    rhtrunc(1:ncol,1:pver) = min(rh(1:ncol,1:pver),1._r8)
@@ -381,7 +383,9 @@ subroutine aer_rad_props_lw(list_idx, state, pbuf,  odap_aer)
       end do
 
       ! calculate relative humidity for table lookup into rh grid
-      call qsat(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), es(1:ncol,1:pver), qs(1:ncol,1:pver), ncol, pver)
+      do k = 1, pver
+         call qsat(state%t(1:ncol,k), state%pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
+      end do
       rh(1:ncol,1:pver) = state%q(1:ncol,1:pver,1) / qs(1:ncol,1:pver)
 
       rhtrunc(1:ncol,1:pver) = min(rh(1:ncol,1:pver),1._r8)

--- a/src/physics/cam/aer_rad_props.F90
+++ b/src/physics/cam/aer_rad_props.F90
@@ -202,9 +202,7 @@ subroutine aer_rad_props_sw(list_idx, state, pbuf,  nnite, idxnite, &
 
    ! calculate relative humidity for table lookup into rh grid
    do k = 1, pver
-      do i = 1, ncol
-         call qsat(state%t(i,k), state%pmid(i,k), es(i,k), qs(i,k))
-      end do
+      call qsat(state%t(1:ncol,k), state%pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
    end do
    rh(1:ncol,1:pver) = state%q(1:ncol,1:pver,1) / qs(1:ncol,1:pver)
 
@@ -386,9 +384,7 @@ subroutine aer_rad_props_lw(list_idx, state, pbuf,  odap_aer)
 
       ! calculate relative humidity for table lookup into rh grid
       do k = 1, pver
-         do i = 1, ncol
-            call qsat(state%t(i,k), state%pmid(i,k), es(i,k), qs(i,k))
-         end do
+         call qsat(state%t(1:ncol,k), state%pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
       end do
       rh(1:ncol,1:pver) = state%q(1:ncol,1:pver,1) / qs(1:ncol,1:pver)
 

--- a/src/physics/cam/cam_diagnostics.F90
+++ b/src/physics/cam/cam_diagnostics.F90
@@ -1313,8 +1313,11 @@ contains
           call pbuf_get_field(pbuf, relhum_idx, ftem_ptr)
           ftem(:ncol,:) = ftem_ptr(:ncol,:)
        else
-          call qsat(state%t(:ncol,:), state%pmid(:ncol,:), &
-                    tem2(:ncol,:), ftem(:ncol,:))
+          do k = 1, pver
+             do i = 1, ncol
+                call qsat(state%t(i,k), state%pmid(i,k), tem2(i,k), ftem(i,k))
+             end do
+          end do
           ftem(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
        end if
        call outfld ('RELHUM  ',ftem    ,pcols   ,lchnk     )
@@ -1323,8 +1326,11 @@ contains
     if (hist_fld_active('RHW') .or. hist_fld_active('RHI') .or. hist_fld_active('RHCFMIP') ) then
 
       ! RH w.r.t liquid (water)
-      call qsat_water (state%t(:ncol,:), state%pmid(:ncol,:), &
-           esl(:ncol,:), ftem(:ncol,:))
+      do k = 1, pver
+         do i = 1, ncol
+            call qsat_water (state%t(i,k), state%pmid(i,k), esl(i,k), ftem(i,k))
+         end do
+      end do
       ftem(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
       call outfld ('RHW  ',ftem    ,pcols   ,lchnk     )
 
@@ -1766,8 +1772,9 @@ contains
       call outfld('U10',      cam_in%u10,       pcols, lchnk)
       !
       ! Calculate and output reference height RH (RHREFHT)
-
-      call qsat(cam_in%tref(:ncol), state%ps(:ncol), tem2(:ncol), ftem(:ncol))
+      do i = 1, ncol
+         call qsat(cam_in%tref(i), state%ps(i), tem2(i), ftem(i))
+      end do
       ftem(:ncol) = cam_in%qref(:ncol)/ftem(:ncol)*100._r8
 
 

--- a/src/physics/cam/cam_diagnostics.F90
+++ b/src/physics/cam/cam_diagnostics.F90
@@ -17,7 +17,7 @@ use constituents,    only: pcnst, cnst_name, cnst_longname, cnst_cam_outfld
 use constituents,    only: ptendnam, dmetendnam, apcnst, bpcnst, cnst_get_ind
 use dycore,          only: dycore_is
 use phys_control,    only: phys_getopts
-use wv_saturation,   only: qsat, qsat_water, svp_ice
+use wv_saturation,   only: qsat, qsat_water, svp_ice_vect
 use time_manager,    only: is_first_step
 
 use scamMod,         only: single_column, wfld
@@ -1331,9 +1331,9 @@ contains
       call outfld ('RHW  ',ftem    ,pcols   ,lchnk     )
 
       ! Convert to RHI (ice)
+      call svp_ice_vect(state%t(1:ncol,1:pver), esi(1:ncol,1:pver), ncol*pver)
       do i=1,ncol
         do k=1,pver
-          esi(i,k)=svp_ice(state%t(i,k))
           ftem1(i,k)=ftem(i,k)*esl(i,k)/esi(i,k)
         end do
       end do

--- a/src/physics/cam/cam_diagnostics.F90
+++ b/src/physics/cam/cam_diagnostics.F90
@@ -1313,7 +1313,9 @@ contains
           call pbuf_get_field(pbuf, relhum_idx, ftem_ptr)
           ftem(:ncol,:) = ftem_ptr(:ncol,:)
        else
-          call qsat(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), tem2(1:ncol,1:pver), ftem(1:ncol,1:pver), ncol, pver)
+          do k = 1, pver
+             call qsat(state%t(1:ncol,k), state%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
+          end do
           ftem(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
        end if
        call outfld ('RELHUM  ',ftem    ,pcols   ,lchnk     )
@@ -1322,16 +1324,18 @@ contains
     if (hist_fld_active('RHW') .or. hist_fld_active('RHI') .or. hist_fld_active('RHCFMIP') ) then
 
       ! RH w.r.t liquid (water)
-      call qsat_water (state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), esl(1:ncol,1:pver), ftem(1:ncol,1:pver), ncol, pver)
+      do k = 1, pver
+         call qsat_water (state%t(1:ncol,k), state%pmid(1:ncol,k), esl(1:ncol,k), ftem(1:ncol,k), ncol)
+      end do
       ftem(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
       call outfld ('RHW  ',ftem    ,pcols   ,lchnk     )
 
       ! Convert to RHI (ice)
-      call svp_ice_vect(state%t(1:ncol,1:pver), esi(1:ncol,1:pver), ncol*pver)
-      do i=1,ncol
-        do k=1,pver
-          ftem1(i,k)=ftem(i,k)*esl(i,k)/esi(i,k)
-        end do
+      do k=1,pver
+         call svp_ice_vect(state%t(1:ncol,k), esi(1:ncol,k), ncol)
+         do i=1,ncol
+            ftem1(i,k)=ftem(i,k)*esl(i,k)/esi(i,k)
+         end do
       end do
       call outfld ('RHI  ',ftem1    ,pcols   ,lchnk     )
 

--- a/src/physics/cam/cam_diagnostics.F90
+++ b/src/physics/cam/cam_diagnostics.F90
@@ -1314,9 +1314,7 @@ contains
           ftem(:ncol,:) = ftem_ptr(:ncol,:)
        else
           do k = 1, pver
-             do i = 1, ncol
-                call qsat(state%t(i,k), state%pmid(i,k), tem2(i,k), ftem(i,k))
-             end do
+             call qsat(state%t(1:ncol,k), state%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
           end do
           ftem(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
        end if
@@ -1327,9 +1325,7 @@ contains
 
       ! RH w.r.t liquid (water)
       do k = 1, pver
-         do i = 1, ncol
-            call qsat_water (state%t(i,k), state%pmid(i,k), esl(i,k), ftem(i,k))
-         end do
+         call qsat_water (state%t(1:ncol,k), state%pmid(1:ncol,k), esl(1:ncol,k), ftem(1:ncol,k), ncol)
       end do
       ftem(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
       call outfld ('RHW  ',ftem    ,pcols   ,lchnk     )
@@ -1772,9 +1768,7 @@ contains
       call outfld('U10',      cam_in%u10,       pcols, lchnk)
       !
       ! Calculate and output reference height RH (RHREFHT)
-      do i = 1, ncol
-         call qsat(cam_in%tref(i), state%ps(i), tem2(i), ftem(i))
-      end do
+      call qsat(cam_in%tref(1:ncol), state%ps(1:ncol), tem2(1:ncol), ftem(1:ncol), ncol)
       ftem(:ncol) = cam_in%qref(:ncol)/ftem(:ncol)*100._r8
 
 

--- a/src/physics/cam/cam_diagnostics.F90
+++ b/src/physics/cam/cam_diagnostics.F90
@@ -1313,9 +1313,7 @@ contains
           call pbuf_get_field(pbuf, relhum_idx, ftem_ptr)
           ftem(:ncol,:) = ftem_ptr(:ncol,:)
        else
-          do k = 1, pver
-             call qsat(state%t(1:ncol,k), state%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
-          end do
+          call qsat(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), tem2(1:ncol,1:pver), ftem(1:ncol,1:pver), ncol, pver)
           ftem(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
        end if
        call outfld ('RELHUM  ',ftem    ,pcols   ,lchnk     )
@@ -1324,9 +1322,7 @@ contains
     if (hist_fld_active('RHW') .or. hist_fld_active('RHI') .or. hist_fld_active('RHCFMIP') ) then
 
       ! RH w.r.t liquid (water)
-      do k = 1, pver
-         call qsat_water (state%t(1:ncol,k), state%pmid(1:ncol,k), esl(1:ncol,k), ftem(1:ncol,k), ncol)
-      end do
+      call qsat_water (state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), esl(1:ncol,1:pver), ftem(1:ncol,1:pver), ncol, pver)
       ftem(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
       call outfld ('RHW  ',ftem    ,pcols   ,lchnk     )
 

--- a/src/physics/cam/cldfrc2m.F90
+++ b/src/physics/cam/cldfrc2m.F90
@@ -1007,10 +1007,9 @@ subroutine aist_vector(qv_in, T_in, p_in, qi_in, ni_in, landfrac_in, snowh_in, a
      esat_in(:)  = 0._r8
      qsat_in(:)  = 0._r8
 
-     call qsat_water(T_in(1:ncol), p_in(1:ncol), &
-          esat_in(1:ncol), qsat_in(1:ncol))
-     
      do i = 1, ncol
+     
+     call qsat_water(T_in(i), p_in(i), esat_in(i), qsat_in(i))
 
      landfrac = landfrac_in(i)     
      snowh = snowh_in(i)   

--- a/src/physics/cam/cldfrc2m.F90
+++ b/src/physics/cam/cldfrc2m.F90
@@ -1007,10 +1007,10 @@ subroutine aist_vector(qv_in, T_in, p_in, qi_in, ni_in, landfrac_in, snowh_in, a
      esat_in(:)  = 0._r8
      qsat_in(:)  = 0._r8
 
+     call qsat_water(T_in(1:ncol), p_in(1:ncol), esat_in(1:ncol), qsat_in(1:ncol), ncol)
+
      do i = 1, ncol
      
-     call qsat_water(T_in(i), p_in(i), esat_in(i), qsat_in(i))
-
      landfrac = landfrac_in(i)     
      snowh = snowh_in(i)   
      T = T_in(i)

--- a/src/physics/cam/cldfrc2m.F90
+++ b/src/physics/cam/cldfrc2m.F90
@@ -6,7 +6,8 @@ use shr_kind_mod,     only: r8=>shr_kind_r8
 use spmd_utils,       only: masterproc
 use ppgrid,           only: pcols
 use physconst,        only: rair
-use wv_saturation,    only: qsat_water, svp_water, svp_ice
+use wv_saturation,    only: qsat_water, svp_water, svp_ice, &
+                            svp_water_vect, svp_ice_vect
 use cam_logfile,      only: iulog
 use cam_abortutils,   only: endrun
 
@@ -951,8 +952,8 @@ subroutine aist_vector(qv_in, T_in, p_in, qi_in, ni_in, landfrac_in, snowh_in, a
    real(r8) ttmp                            ! Limited temperature
    real(r8) icicval                         ! Empirical IWC value [ kg/kg ]
    real(r8) rho                             ! Local air density
-   real(r8) esl                             ! Liq sat vapor pressure
-   real(r8) esi                             ! Ice sat vapor pressure
+   real(r8) esl(pcols)                      ! Liq sat vapor pressure
+   real(r8) esi(pcols)                      ! Ice sat vapor pressure
    real(r8) ncf,phi                         ! Wilson and Ballard parameters
    real(r8) qs
    real(r8) esat_in(pcols)
@@ -1008,6 +1009,8 @@ subroutine aist_vector(qv_in, T_in, p_in, qi_in, ni_in, landfrac_in, snowh_in, a
      qsat_in(:)  = 0._r8
 
      call qsat_water(T_in(1:ncol), p_in(1:ncol), esat_in(1:ncol), qsat_in(1:ncol), ncol)
+     call svp_water_vect(T_in(1:ncol), esl(1:ncol), ncol)
+     call svp_ice_vect(T_in(1:ncol), esi(1:ncol), ncol)
 
      do i = 1, ncol
      
@@ -1019,8 +1022,6 @@ subroutine aist_vector(qv_in, T_in, p_in, qi_in, ni_in, landfrac_in, snowh_in, a
      qi = qi_in(i)
      ni = ni_in(i)
      qs = qsat_in(i)
-     esl = svp_water(T)
-     esi = svp_ice(T)
 
      if (present(rhmaxi_in))          rhmaxi          = rhmaxi_in(i)
      if (present(rhmini_in))          rhmini          = rhmini_in(i)      
@@ -1041,7 +1042,7 @@ subroutine aist_vector(qv_in, T_in, p_in, qi_in, ni_in, landfrac_in, snowh_in, a
          endif
          aist =  max(0._r8,min(qi/icicval,1._r8)) 
      elseif( iceopt.eq.3 ) then
-         aist = 1._r8 - exp(-Kc*qi/(qs*(esi/esl)))
+         aist = 1._r8 - exp(-Kc*qi/(qs*(esi(i)/esl(i))))
          aist = max(0._r8,min(aist,1._r8))
      elseif( iceopt.eq.4) then
          if( p .ge. premib ) then
@@ -1074,7 +1075,7 @@ subroutine aist_vector(qv_in, T_in, p_in, qi_in, ni_in, landfrac_in, snowh_in, a
              aist = max(0._r8,min(aist,1._r8))
      elseif (iceopt.eq.5) then 
         ! set rh ice cloud fraction
-        rhi= (qv+qi)/qs * (esl/esi)
+        rhi= (qv+qi)/qs * (esl(i)/esi(i))
         if (rhmaxi .eq. rhmini) then
            if (rhi .gt. rhmini) then
               rhdif = 1._r8

--- a/src/physics/cam/cldwat.F90
+++ b/src/physics/cam/cldwat.F90
@@ -440,9 +440,9 @@ subroutine pcond (lchnk   ,ncol    ,troplev ,dlat    , &
       call findsp_vc(qn(:ncol,k), tn(:ncol,k), p(:ncol,k), .true., &
            tsp(:ncol,k), qsp(:ncol,k))
 
-      call qsat(t(:ncol,k), p(:ncol,k), &
-           es(:ncol), qs(:ncol), gam=gamma(:ncol))
       do i = 1,ncol
+         call qsat(t(i,k), p(i,k), es(i), qs(i), gam=gamma(i))
+!
          relhum(i) = q(i,k)/qs(i)
 !
          cldm(i) = max(cldn(i,k),mincld)

--- a/src/physics/cam/cldwat.F90
+++ b/src/physics/cam/cldwat.F90
@@ -440,8 +440,9 @@ subroutine pcond (lchnk   ,ncol    ,troplev ,dlat    , &
       call findsp_vc(qn(:ncol,k), tn(:ncol,k), p(:ncol,k), .true., &
            tsp(:ncol,k), qsp(:ncol,k))
 
+      call qsat(t(1:ncol,k), p(1:ncol,k), es(1:ncol), qs(1:ncol), ncol, gam=gamma(1:ncol))
+
       do i = 1,ncol
-         call qsat(t(i,k), p(i,k), es(i), qs(i), gam=gamma(i))
 !
          relhum(i) = q(i,k)/qs(i)
 !
@@ -777,6 +778,7 @@ subroutine pcond (lchnk   ,ncol    ,troplev ,dlat    , &
 ! residual of over-saturation because theoretically, cme
 ! should have taken care of all of large scale condensation.
 ! 
+
 
        do i = 1,ncol
           qtmp = qn(i,k)-(cme(i,k)-evapprec(i,k))*deltat

--- a/src/physics/cam/cldwat.F90
+++ b/src/physics/cam/cldwat.F90
@@ -314,20 +314,20 @@ subroutine pcond (lchnk   ,ncol    ,troplev ,dlat    , &
    real(r8) cwn(pcols)           ! cwat mixing ratio at end
    real(r8) denom                ! work variable
    real(r8) dqsdt                ! change in sat spec. hum. wrt temperature
-   real(r8) es(pcols,pver)       ! sat. vapor pressure
+   real(r8) es(pcols)            ! sat. vapor pressure
    real(r8) fracw(pcols,pver)    ! relative importance of collection of liquid by rain
    real(r8) fsaci(pcols,pver)    ! relative importance of collection of ice by snow
    real(r8) fsacw(pcols,pver)    ! relative importance of collection of liquid by snow
    real(r8) fsaut(pcols,pver)    ! relative importance of ice auto conversion
    real(r8) fwaut(pcols,pver)    ! relative importance of warm cloud autoconversion
-   real(r8) gamma(pcols,pver)    ! d qs / dT
+   real(r8) gamma(pcols)         ! d qs / dT
    real(r8) icwc(pcols)          ! in-cloud water content (kg/kg)
    real(r8) mincld               ! a small cloud fraction to avoid / zero
    real(r8),parameter ::omsm=0.99999_r8                 ! a number just less than unity (for rounding)
    real(r8) prprov(pcols)        ! provisional value of precip at btm of layer
    real(r8) prtmp                ! work variable
    real(r8) q(pcols,pver)        ! mixing ratio before time step ignoring condensate
-   real(r8) qs(pcols,pver)       ! spec. hum. of water vapor
+   real(r8) qs(pcols)            ! spec. hum. of water vapor
    real(r8) qsn, esn             ! work variable
    real(r8) qsp(pcols,pver)      ! sat pt mixing ratio
    real(r8) qtl(pcols)           ! tendency which would saturate the grid box in deltat
@@ -431,9 +431,6 @@ subroutine pcond (lchnk   ,ncol    ,troplev ,dlat    , &
    psacwo(:ncol,:) = 0._r8
    psacio(:ncol,:) = 0._r8
 
-   call qsat(t(1:ncol,top_lev:pver), p(1:ncol,top_lev:pver), es(1:ncol,top_lev:pver), & 
-             qs(1:ncol,top_lev:pver), ncol, pver-top_lev+1, gam=gamma(1:ncol,top_lev:pver))
-
 !
 ! find the wet bulb temp and saturation value
 ! for the provisional t and q without condensation
@@ -444,9 +441,11 @@ subroutine pcond (lchnk   ,ncol    ,troplev ,dlat    , &
       call findsp_vc(qn(:ncol,k), tn(:ncol,k), p(:ncol,k), .true., &
            tsp(:ncol,k), qsp(:ncol,k))
 
+      call qsat(t(1:ncol,k), p(1:ncol,k), es(1:ncol), qs(1:ncol), ncol, gam=gamma(1:ncol))
+
       do i = 1,ncol
 !
-         relhum(i) = q(i,k)/qs(i,k)
+         relhum(i) = q(i,k)/qs(i)
 !
          cldm(i) = max(cldn(i,k),mincld)
 !
@@ -456,9 +455,9 @@ subroutine pcond (lchnk   ,ncol    ,troplev ,dlat    , &
 
 ! define the coefficients for C - E calculation
 
-         calpha(i) = 1.0_r8/qs(i,k)
-         cbeta (i) = q(i,k)/qs(i,k)**2*gamma(i,k)*cpohl
-         cbetah(i) = 1.0_r8/qs(i,k)*gamma(i,k)*cpohl
+         calpha(i) = 1.0_r8/qs(i)
+         cbeta (i) = q(i,k)/qs(i)**2*gamma(i)*cpohl
+         cbetah(i) = 1.0_r8/qs(i)*gamma(i)*cpohl
          cgamma(i) = calpha(i)+latvap*cbeta(i)/cpair
          cgamah(i) = calpha(i)+latvap*cbetah(i)/cpair
          rcgama(i) = cgamma(i)/cgamah(i)
@@ -604,7 +603,7 @@ subroutine pcond (lchnk   ,ncol    ,troplev ,dlat    , &
 ! as a safe limit, condensation should not reduce grid mean rh below rhu00
 ! 
            if(cme(i,k) > 0.0_r8 .and. relhum(i) > rhu_adj(i,k) )  &
-              cme(i,k) = min(cme(i,k), (qn(i,k)-qs(i,k)*rhu_adj(i,k))/deltat)
+              cme(i,k) = min(cme(i,k), (qn(i,k)-qs(i)*rhu_adj(i,k))/deltat)
 !
 ! initial guess for cwm (mean cloud water over time step) if 1st iteration
 !

--- a/src/physics/cam/cldwat2m_macro.F90
+++ b/src/physics/cam/cldwat2m_macro.F90
@@ -812,8 +812,9 @@
    do k = top_lev, pver
       call findsp_vc(qv_05(:ncol,k), T_05(:ncol,k), p(:ncol,k), .false., &
                      Twb_aw(:ncol), qvwb_aw(:ncol,k))
-      call qsat_water(T_05(1:ncol,k), p(1:ncol,k), &
-                      esat_a(1:ncol), qsat_a(1:ncol,k))
+      do i = 1, ncol
+         call qsat_water(T_05(i,k), p(i,k), esat_a(i), qsat_a(i,k))
+      end do
    enddo
 
    do iter = 1, niter
@@ -839,10 +840,9 @@
       bb(:,:)         = 0._r8
 
       do k = top_lev, pver
-
-      call qsat_water(T(1:ncol,k), p(1:ncol,k), &
-                      esat_b(1:ncol), qsat_b(1:ncol), dqsdt=dqsdT_b(1:ncol))
-
+         do i = 1, ncol
+            call qsat_water(T(i,k), p(i,k), esat_b(i), qsat_b(i), dqsdt=dqsdT_b(i))
+         end do
       if( iter .eq. 1 ) then
           a_cu(:ncol,k) = a_cud(:ncol,k)
       else
@@ -1326,9 +1326,8 @@ subroutine rhcrit_calc( &
       ! Compute the drop of critical RH by the variability induced by PBL turbulence
 
       do k = top_lev, pver
-         call qsat_ice(T0(1:ncol,k), p(1:ncol,k), esat_tmp(1:ncol), qsat_tmp(1:ncol))
-
          do i = 1, ncol
+            call qsat_ice(T0(i,k), p(i,k), esat_tmp(i), qsat_tmp(i))
             sig_tmp = 0.5_r8 * ( qti_flx(i,k)   / sqrt(max(qsmall,tke(i,k))) + & 
                                  qti_flx(i,k+1) / sqrt(max(qsmall,tke(i,k+1))) )
             d_rhmin_ice_PBL(i,k) = c_aniso*sig_tmp/max(qsmall,qsat_tmp(i)) 
@@ -1378,9 +1377,8 @@ subroutine rhcrit_calc( &
       ! Compute the drop of critical RH by the variability induced by PBL turbulence
 
       do k = top_lev, pver
-         call qsat_water(T0(1:ncol,k), p(1:ncol,k), esat_tmp(1:ncol), qsat_tmp(1:ncol))
-
          do i = 1, ncol
+            call qsat_water(T0(i,k), p(i,k), esat_tmp(i), qsat_tmp(i))
             sig_tmp = 0.5_r8 * ( qtl_flx(i,k)   / sqrt(max(qsmall,tke(i,k))) + & 
                                  qtl_flx(i,k+1) / sqrt(max(qsmall,tke(i,k+1))) )
             d_rhmin_liq_PBL(i,k) = c_aniso*sig_tmp/max(qsmall,qsat_tmp(i)) 
@@ -1529,8 +1527,9 @@ end subroutine rhcrit_calc
    ! Main Computation ! 
    ! ---------------- !
 
-   call qsat_water(T0_in(1:ncol), p_in(1:ncol), &
-        esat_in(1:ncol), qsat_in(1:ncol))
+   do i = 1, ncol
+      call qsat_water(T0_in(i), p_in(i), esat_in(i), qsat_in(i))
+   end do
    U0_in(:ncol) = qv0_in(:ncol)/qsat_in(:ncol)
    if( CAMstfrac ) then
        call astG_RHU(U0_in(:),p_in(:),qv0_in(:),landfrac(:),snowh(:),al0_st_nc_in(:),G0_nc_in(:),ncol,&

--- a/src/physics/cam/cldwat2m_macro.F90
+++ b/src/physics/cam/cldwat2m_macro.F90
@@ -434,9 +434,9 @@
    real(r8) Twb_aw(pcols)                             ! Wet-bulb temperature [K]
    real(r8) qvwb_aw(pcols,pver)                       ! Wet-bulb water vapor specific humidity [kg/kg]
 
-   real(r8) esat_b(pcols)                                 
-   real(r8) qsat_b(pcols)                                 
-   real(r8) dqsdT_b(pcols)                                 
+   real(r8) esat_b(pcols,pver) 
+   real(r8) qsat_b(pcols,pver)                                 
+   real(r8) dqsdT_b(pcols,pver)                                 
 
    logical  land
    real(r8) tmp
@@ -837,15 +837,16 @@
       aa(:,:)         = 0._r8
       bb(:,:)         = 0._r8
 
+      call qsat_water(T(1:ncol,top_lev:pver), p(1:ncol,top_lev:pver), esat_b(1:ncol,top_lev:pver), &
+                      qsat_b(1:ncol,top_lev:pver), ncol, pver-top_lev+1, dqsdt=dqsdT_b(1:ncol,top_lev:pver))
       do k = top_lev, pver
-         call qsat_water(T(1:ncol,k), p(1:ncol,k), esat_b(1:ncol), qsat_b(1:ncol), ncol, dqsdt=dqsdT_b(1:ncol))
       if( iter .eq. 1 ) then
           a_cu(:ncol,k) = a_cud(:ncol,k)
       else
           a_cu(:ncol,k) = a_cu0(:ncol,k)
       endif
       do i = 1, ncol
-         U(i,k)    =  qv(i,k)/qsat_b(i)
+         U(i,k)    =  qv(i,k)/qsat_b(i,k)
          U_nc(i,k) =  U(i,k)
       enddo
       if( CAMstfrac ) then
@@ -868,9 +869,9 @@
          ! Compute basic thermodynamic coefficients for computing Q !
          ! -------------------------------------------------------- !
 
-         alpha  =  1._r8/qsat_b(i)
-         beta   =  dqsdT_b(i)*(qv(i,k)/qsat_b(i)**2)
-         betast =  alpha*dqsdT_b(i) 
+         alpha  =  1._r8/qsat_b(i,k)
+         beta   =  dqsdT_b(i,k)*(qv(i,k)/qsat_b(i,k)**2)
+         betast =  alpha*dqsdT_b(i,k) 
          gammal =  alpha + (latvap/cpair)*beta
          gammai =  alpha + ((latvap+latice)/cpair)*beta
          gammaQ =  alpha + (latvap/cpair)*beta
@@ -1287,8 +1288,8 @@ subroutine rhcrit_calc( &
 
    integer :: i, k
 
-   real(r8) :: esat_tmp(pcols)          ! Dummy for saturation vapor pressure calc.
-   real(r8) :: qsat_tmp(pcols)          ! Saturation water vapor specific humidity [kg/kg]
+   real(r8) :: esat_tmp(pcols,pver)          ! Dummy for saturation vapor pressure calc.
+   real(r8) :: qsat_tmp(pcols,pver)          ! Saturation water vapor specific humidity [kg/kg]
    real(r8) :: sig_tmp
    !---------------------------------------------------------------------------------------------------
 
@@ -1320,13 +1321,13 @@ subroutine rhcrit_calc( &
    if (i_rhmini == 2) then
 
       ! Compute the drop of critical RH by the variability induced by PBL turbulence
-
+      call qsat_ice(T0(1:ncol,top_lev:pver), p(1:ncol,top_lev:pver), esat_tmp(1:ncol,top_lev:pver), &
+                    qsat_tmp(1:ncol,top_lev:pver), ncol, pver-top_lev+1)
       do k = top_lev, pver
-         call qsat_ice(T0(1:ncol,k), p(1:ncol,k), esat_tmp(1:ncol), qsat_tmp(1:ncol), ncol)
          do i = 1, ncol
             sig_tmp = 0.5_r8 * ( qti_flx(i,k)   / sqrt(max(qsmall,tke(i,k))) + & 
                                  qti_flx(i,k+1) / sqrt(max(qsmall,tke(i,k+1))) )
-            d_rhmin_ice_PBL(i,k) = c_aniso*sig_tmp/max(qsmall,qsat_tmp(i)) 
+            d_rhmin_ice_PBL(i,k) = c_aniso*sig_tmp/max(qsmall,qsat_tmp(i,k)) 
             d_rhmin_ice_PBL(i,k) = max(0._r8,min(0.5_r8,d_rhmin_ice_PBL(i,k)))
 
             rhmini_arr(i,k) = 1._r8 - d_rhmin_ice_PBL(i,k) - d_rhmin_ice_det(i,k)
@@ -1371,13 +1372,14 @@ subroutine rhcrit_calc( &
    if (i_rhminl == 2) then
 
       ! Compute the drop of critical RH by the variability induced by PBL turbulence
+      call qsat_water(T0(1:ncol,top_lev:pver), p(1:ncol,top_lev:pver), esat_tmp(1:ncol,top_lev:pver), &
+                      qsat_tmp(1:ncol,top_lev:pver), ncol, pver-top_lev+1)
 
       do k = top_lev, pver
-         call qsat_water(T0(1:ncol,k), p(1:ncol,k), esat_tmp(1:ncol), qsat_tmp(1:ncol), ncol)
          do i = 1, ncol
             sig_tmp = 0.5_r8 * ( qtl_flx(i,k)   / sqrt(max(qsmall,tke(i,k))) + & 
                                  qtl_flx(i,k+1) / sqrt(max(qsmall,tke(i,k+1))) )
-            d_rhmin_liq_PBL(i,k) = c_aniso*sig_tmp/max(qsmall,qsat_tmp(i)) 
+            d_rhmin_liq_PBL(i,k) = c_aniso*sig_tmp/max(qsmall,qsat_tmp(i,k)) 
             d_rhmin_liq_PBL(i,k) = max(0._r8,min(0.5_r8,d_rhmin_liq_PBL(i,k)))
 
             rhminl_arr(i,k) = 1._r8 - d_rhmin_liq_PBL(i,k) - d_rhmin_liq_det(i,k)

--- a/src/physics/cam/cldwat2m_macro.F90
+++ b/src/physics/cam/cldwat2m_macro.F90
@@ -812,9 +812,7 @@
    do k = top_lev, pver
       call findsp_vc(qv_05(:ncol,k), T_05(:ncol,k), p(:ncol,k), .false., &
                      Twb_aw(:ncol), qvwb_aw(:ncol,k))
-      do i = 1, ncol
-         call qsat_water(T_05(i,k), p(i,k), esat_a(i), qsat_a(i,k))
-      end do
+      call qsat_water(T_05(1:ncol,k), p(1:ncol,k), esat_a(1:ncol), qsat_a(1:ncol,k), ncol)
    enddo
 
    do iter = 1, niter
@@ -840,9 +838,7 @@
       bb(:,:)         = 0._r8
 
       do k = top_lev, pver
-         do i = 1, ncol
-            call qsat_water(T(i,k), p(i,k), esat_b(i), qsat_b(i), dqsdt=dqsdT_b(i))
-         end do
+         call qsat_water(T(1:ncol,k), p(1:ncol,k), esat_b(1:ncol), qsat_b(1:ncol), ncol, dqsdt=dqsdT_b(1:ncol))
       if( iter .eq. 1 ) then
           a_cu(:ncol,k) = a_cud(:ncol,k)
       else
@@ -1326,8 +1322,8 @@ subroutine rhcrit_calc( &
       ! Compute the drop of critical RH by the variability induced by PBL turbulence
 
       do k = top_lev, pver
+         call qsat_ice(T0(1:ncol,k), p(1:ncol,k), esat_tmp(1:ncol), qsat_tmp(1:ncol), ncol)
          do i = 1, ncol
-            call qsat_ice(T0(i,k), p(i,k), esat_tmp(i), qsat_tmp(i))
             sig_tmp = 0.5_r8 * ( qti_flx(i,k)   / sqrt(max(qsmall,tke(i,k))) + & 
                                  qti_flx(i,k+1) / sqrt(max(qsmall,tke(i,k+1))) )
             d_rhmin_ice_PBL(i,k) = c_aniso*sig_tmp/max(qsmall,qsat_tmp(i)) 
@@ -1377,8 +1373,8 @@ subroutine rhcrit_calc( &
       ! Compute the drop of critical RH by the variability induced by PBL turbulence
 
       do k = top_lev, pver
+         call qsat_water(T0(1:ncol,k), p(1:ncol,k), esat_tmp(1:ncol), qsat_tmp(1:ncol), ncol)
          do i = 1, ncol
-            call qsat_water(T0(i,k), p(i,k), esat_tmp(i), qsat_tmp(i))
             sig_tmp = 0.5_r8 * ( qtl_flx(i,k)   / sqrt(max(qsmall,tke(i,k))) + & 
                                  qtl_flx(i,k+1) / sqrt(max(qsmall,tke(i,k+1))) )
             d_rhmin_liq_PBL(i,k) = c_aniso*sig_tmp/max(qsmall,qsat_tmp(i)) 
@@ -1527,9 +1523,7 @@ end subroutine rhcrit_calc
    ! Main Computation ! 
    ! ---------------- !
 
-   do i = 1, ncol
-      call qsat_water(T0_in(i), p_in(i), esat_in(i), qsat_in(i))
-   end do
+   call qsat_water(T0_in(1:ncol), p_in(1:ncol), esat_in(1:ncol), qsat_in(1:ncol), ncol)
    U0_in(:ncol) = qv0_in(:ncol)/qsat_in(:ncol)
    if( CAMstfrac ) then
        call astG_RHU(U0_in(:),p_in(:),qv0_in(:),landfrac(:),snowh(:),al0_st_nc_in(:),G0_nc_in(:),ncol,&

--- a/src/physics/cam/cloud_fraction.F90
+++ b/src/physics/cam/cloud_fraction.F90
@@ -409,14 +409,19 @@ subroutine cldfrc(lchnk   ,ncol    , pbuf,  &
     ! Evaluate potential temperature and relative humidity
     ! If not computing ice cloud fraction then hybrid RH, if MG then water RH
     if ( cldfrc_ice ) then
-       call qsat_water(temp(1:ncol,top_lev:pver), pmid(1:ncol,top_lev:pver), &
-            esl(1:ncol,top_lev:pver), qs(1:ncol,top_lev:pver))
-
-       esi(1:ncol,top_lev:pver) = svp_ice(temp(1:ncol,top_lev:pver))
+       do k = top_lev,pver
+          do i = 1,ncol
+             call qsat_water(temp(i,k), pmid(i,k), esl(i,k), qs(i,k))
+             esi(i,k) = svp_ice(temp(i,k))
+          end do
+       end do
     else
-       call qsat(temp(1:ncol,top_lev:pver), pmid(1:ncol,top_lev:pver), &
-            es(1:ncol,top_lev:pver), qs(1:ncol,top_lev:pver))
-    endif
+       do k = top_lev,pver
+          do i = 1,ncol
+             call qsat(temp(i,k), pmid(i,k), es(i,k), qs(i,k))
+          end do
+       end do
+    end if
 
     cloud    = 0._r8
     icecldf  = 0._r8

--- a/src/physics/cam/cloud_fraction.F90
+++ b/src/physics/cam/cloud_fraction.F90
@@ -264,7 +264,7 @@ subroutine cldfrc(lchnk   ,ncol    , pbuf,  &
     !-----------------------------------------------------------------------
     use cam_history,   only: outfld
     use physconst,     only: cappa, gravit, rair, tmelt
-    use wv_saturation, only: qsat, qsat_water, svp_ice
+    use wv_saturation, only: qsat, qsat_water, svp_ice_vect
     use phys_grid,     only: get_rlat_all_p, get_rlon_all_p
 
    
@@ -411,9 +411,7 @@ subroutine cldfrc(lchnk   ,ncol    , pbuf,  &
     if ( cldfrc_ice ) then
        do k = top_lev,pver
           call qsat_water(temp(1:ncol,k), pmid(1:ncol,k), esl(1:ncol,k), qs(1:ncol,k), ncol)
-          do i = 1, ncol
-             esi(i,k) = svp_ice(temp(i,k))
-          end do
+          call svp_ice_vect(temp(1:ncol,k), esi(1:ncol,k), ncol)
        end do
     else
        do k = top_lev,pver

--- a/src/physics/cam/cloud_fraction.F90
+++ b/src/physics/cam/cloud_fraction.F90
@@ -409,12 +409,14 @@ subroutine cldfrc(lchnk   ,ncol    , pbuf,  &
     ! Evaluate potential temperature and relative humidity
     ! If not computing ice cloud fraction then hybrid RH, if MG then water RH
     if ( cldfrc_ice ) then
-       call qsat_water(temp(1:ncol,top_lev:pver), pmid(1:ncol,top_lev:pver), esl(1:ncol,top_lev:pver), &
-                       qs(1:ncol,top_lev:pver), ncol, pver-top_lev+1)
-       call svp_ice_vect(temp(1:ncol,top_lev:pver), esi(1:ncol,top_lev:pver), ncol*(pver-top_lev+1))
+       do k = top_lev,pver
+          call qsat_water(temp(1:ncol,k), pmid(1:ncol,k), esl(1:ncol,k), qs(1:ncol,k), ncol)
+          call svp_ice_vect(temp(1:ncol,k), esi(1:ncol,k), ncol)
+       end do
     else
-       call qsat(temp(1:ncol,top_lev:pver), pmid(1:ncol,top_lev:pver), es(1:ncol,top_lev:pver), &
-                 qs(1:ncol,top_lev:pver), ncol, pver-top_lev+1)
+       do k = top_lev,pver
+          call qsat(temp(1:ncol,k), pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
+       end do
     end if
 
     cloud    = 0._r8

--- a/src/physics/cam/cloud_fraction.F90
+++ b/src/physics/cam/cloud_fraction.F90
@@ -410,16 +410,14 @@ subroutine cldfrc(lchnk   ,ncol    , pbuf,  &
     ! If not computing ice cloud fraction then hybrid RH, if MG then water RH
     if ( cldfrc_ice ) then
        do k = top_lev,pver
-          do i = 1,ncol
-             call qsat_water(temp(i,k), pmid(i,k), esl(i,k), qs(i,k))
+          call qsat_water(temp(1:ncol,k), pmid(1:ncol,k), esl(1:ncol,k), qs(1:ncol,k), ncol)
+          do i = 1, ncol
              esi(i,k) = svp_ice(temp(i,k))
           end do
        end do
     else
        do k = top_lev,pver
-          do i = 1,ncol
-             call qsat(temp(i,k), pmid(i,k), es(i,k), qs(i,k))
-          end do
+          call qsat(temp(1:ncol,k), pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
        end do
     end if
 

--- a/src/physics/cam/cloud_fraction.F90
+++ b/src/physics/cam/cloud_fraction.F90
@@ -409,14 +409,12 @@ subroutine cldfrc(lchnk   ,ncol    , pbuf,  &
     ! Evaluate potential temperature and relative humidity
     ! If not computing ice cloud fraction then hybrid RH, if MG then water RH
     if ( cldfrc_ice ) then
-       do k = top_lev,pver
-          call qsat_water(temp(1:ncol,k), pmid(1:ncol,k), esl(1:ncol,k), qs(1:ncol,k), ncol)
-          call svp_ice_vect(temp(1:ncol,k), esi(1:ncol,k), ncol)
-       end do
+       call qsat_water(temp(1:ncol,top_lev:pver), pmid(1:ncol,top_lev:pver), esl(1:ncol,top_lev:pver), &
+                       qs(1:ncol,top_lev:pver), ncol, pver-top_lev+1)
+       call svp_ice_vect(temp(1:ncol,top_lev:pver), esi(1:ncol,top_lev:pver), ncol*(pver-top_lev+1))
     else
-       do k = top_lev,pver
-          call qsat(temp(1:ncol,k), pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
-       end do
+       call qsat(temp(1:ncol,top_lev:pver), pmid(1:ncol,top_lev:pver), es(1:ncol,top_lev:pver), &
+                 qs(1:ncol,top_lev:pver), ncol, pver-top_lev+1)
     end if
 
     cloud    = 0._r8

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -1893,11 +1893,14 @@ end subroutine clubb_init_cnst
      qitend(:ncol,:)=0._r8
      initend(:ncol,:)=0._r8
 
-     call ice_macro_tend(naai(:ncol,top_lev:pver),state1%t(:ncol,top_lev:pver), &
-        state1%pmid(:ncol,top_lev:pver),state1%q(:ncol,top_lev:pver,1),state1%q(:ncol,top_lev:pver,ixcldice),&
-        state1%q(:ncol,top_lev:pver,ixnumice),latsub,hdtime,&
-        stend(:ncol,top_lev:pver),qvtend(:ncol,top_lev:pver),qitend(:ncol,top_lev:pver),&
-        initend(:ncol,top_lev:pver))
+     do k = top_lev, pver
+        do i = 1, ncol
+           call ice_macro_tend(naai(i,k),state1%t(i,k),state1%pmid(i,k),      &
+                               state1%q(i,k,1),state1%q(i,k,ixcldice),        &
+                               state1%q(i,k,ixnumice),latsub,hdtime,          &
+                               stend(i,k),qvtend(i,k),qitend(i,k),initend(i,k))
+        end do
+     end do
 
     ! update local copy of state with the tendencies
      ptend_loc%q(:ncol,top_lev:pver,1)=qvtend(:ncol,top_lev:pver)
@@ -2796,12 +2799,15 @@ end subroutine clubb_init_cnst
       qctend(:ncol,:)=0._r8
       inctend(:ncol,:)=0._r8
  
-      call liquid_macro_tend(npccn(:ncol,top_lev:pver),state1%t(:ncol,top_lev:pver), &
-         state1%pmid(:ncol,top_lev:pver),state1%q(:ncol,top_lev:pver,ixq),state1%q(:ncol,top_lev:pver,ixcldliq),&
-         state1%q(:ncol,top_lev:pver,ixnumliq),latvap,hdtime,&
-         stend(:ncol,top_lev:pver),qvtend(:ncol,top_lev:pver),qctend(:ncol,top_lev:pver),&
-         inctend(:ncol,top_lev:pver))
- 
+      do k = top_lev, pver
+         do i = 1, ncol
+            call liquid_macro_tend(npccn(i,k),state1%t(i,k), state1%pmid(i,k),    &
+                                   state1%q(i,k,ixq),state1%q(i,k,ixcldliq),      &
+                                   state1%q(i,k,ixnumliq),latvap,hdtime,          &
+                                   stend(i,k),qvtend(i,k),qctend(i,k),inctend(i,k))
+         end do
+      end do
+
       ! update local copy of state with the tendencies
       ptend_loc%q(:ncol,top_lev:pver,ixq)=qvtend(:ncol,top_lev:pver)
       ptend_loc%q(:ncol,top_lev:pver,ixcldliq)=qctend(:ncol,top_lev:pver)
@@ -3269,7 +3275,7 @@ end subroutine clubb_init_cnst
 
 ! Saturation adjustment for ice
 ! Add ice mass if supersaturated
-elemental subroutine ice_macro_tend(naai,t,p,qv,qi,ni,xxls,deltat,stend,qvtend,qitend,nitend) 
+subroutine ice_macro_tend(naai,t,p,qv,qi,ni,xxls,deltat,stend,qvtend,qitend,nitend) 
 
   use wv_sat_methods, only: wv_sat_qsat_ice
 

--- a/src/physics/cam/clubb_intr.F90
+++ b/src/physics/cam/clubb_intr.F90
@@ -1893,14 +1893,11 @@ end subroutine clubb_init_cnst
      qitend(:ncol,:)=0._r8
      initend(:ncol,:)=0._r8
 
-     do k = top_lev, pver
-        do i = 1, ncol
-           call ice_macro_tend(naai(i,k),state1%t(i,k),state1%pmid(i,k),      &
-                               state1%q(i,k,1),state1%q(i,k,ixcldice),        &
-                               state1%q(i,k,ixnumice),latsub,hdtime,          &
-                               stend(i,k),qvtend(i,k),qitend(i,k),initend(i,k))
-        end do
-     end do
+     call ice_macro_tend(naai(1:ncol,top_lev:pver), state1%t(1:ncol,top_lev:pver),                       &
+                         state1%pmid(1:ncol,top_lev:pver), state1%q(1:ncol,top_lev:pver,1),              &
+                         state1%q(1:ncol,top_lev:pver,ixcldice), state1%q(1:ncol,top_lev:pver,ixnumice), &
+                         latsub, hdtime, stend(1:ncol,top_lev:pver), qvtend(1:ncol,top_lev:pver),        &
+                         qitend(1:ncol,top_lev:pver), initend(1:ncol,top_lev:pver), ncol*(pver-top_lev+1))
 
     ! update local copy of state with the tendencies
      ptend_loc%q(:ncol,top_lev:pver,1)=qvtend(:ncol,top_lev:pver)
@@ -2799,14 +2796,11 @@ end subroutine clubb_init_cnst
       qctend(:ncol,:)=0._r8
       inctend(:ncol,:)=0._r8
  
-      do k = top_lev, pver
-         do i = 1, ncol
-            call liquid_macro_tend(npccn(i,k),state1%t(i,k), state1%pmid(i,k),    &
-                                   state1%q(i,k,ixq),state1%q(i,k,ixcldliq),      &
-                                   state1%q(i,k,ixnumliq),latvap,hdtime,          &
-                                   stend(i,k),qvtend(i,k),qctend(i,k),inctend(i,k))
-         end do
-      end do
+      call liquid_macro_tend(npccn(1:ncol,top_lev:pver), state1%t(1:ncol,top_lev:pver),                      &
+                             state1%pmid(1:ncol,top_lev:pver), state1%q(1:ncol,top_lev:pver,ixq),            &
+                             state1%q(1:ncol,top_lev:pver,ixcldliq), state1%q(1:ncol,top_lev:pver,ixnumliq), &
+                             latvap, hdtime, stend(1:ncol,top_lev:pver),qvtend(1:ncol,top_lev:pver),         &
+                             qctend(1:ncol,top_lev:pver), inctend(1:ncol,top_lev:pver), ncol*(pver-top_lev+1))
 
       ! update local copy of state with the tendencies
       ptend_loc%q(:ncol,top_lev:pver,ixq)=qvtend(:ncol,top_lev:pver)
@@ -3275,50 +3269,53 @@ end subroutine clubb_init_cnst
 
 ! Saturation adjustment for ice
 ! Add ice mass if supersaturated
-subroutine ice_macro_tend(naai,t,p,qv,qi,ni,xxls,deltat,stend,qvtend,qitend,nitend) 
+subroutine ice_macro_tend(naai,t,p,qv,qi,ni,xxls,deltat,stend,qvtend,qitend,nitend,vlen) 
 
-  use wv_sat_methods, only: wv_sat_qsat_ice
+  use wv_sat_methods, only: wv_sat_qsat_ice_vect
 
-  real(r8), intent(in)  :: naai   !Activated number of ice nuclei 
-  real(r8), intent(in)  :: t      !temperature (k)
-  real(r8), intent(in)  :: p      !pressure (pa0
-  real(r8), intent(in)  :: qv     !water vapor mixing ratio
-  real(r8), intent(in)  :: qi     !ice mixing ratio
-  real(r8), intent(in)  :: ni     !ice number concentration
-  real(r8), intent(in)  :: xxls   !latent heat of freezing
-  real(r8), intent(in)  :: deltat !timestep
-  real(r8), intent(out) :: stend  ! 'temperature' tendency 
-  real(r8), intent(out) :: qvtend !vapor tendency
-  real(r8), intent(out) :: qitend !ice mass tendency
-  real(r8), intent(out) :: nitend !ice number tendency  
+  integer,                   intent(in)  :: vlen
+  real(r8), dimension(vlen), intent(in)  :: naai   !Activated number of ice nuclei 
+  real(r8), dimension(vlen), intent(in)  :: t      !temperature (k)
+  real(r8), dimension(vlen), intent(in)  :: p      !pressure (pa0
+  real(r8), dimension(vlen), intent(in)  :: qv     !water vapor mixing ratio
+  real(r8), dimension(vlen), intent(in)  :: qi     !ice mixing ratio
+  real(r8), dimension(vlen), intent(in)  :: ni     !ice number concentration
+  real(r8),                  intent(in)  :: xxls   !latent heat of freezing
+  real(r8),                  intent(in)  :: deltat !timestep
+  real(r8), dimension(vlen), intent(out) :: stend  ! 'temperature' tendency 
+  real(r8), dimension(vlen), intent(out) :: qvtend !vapor tendency
+  real(r8), dimension(vlen), intent(out) :: qitend !ice mass tendency
+  real(r8), dimension(vlen), intent(out) :: nitend !ice number tendency  
  
-  real(r8) :: ESI
-  real(r8) :: QSI
-  real(r8) :: tau
+  real(r8) :: ESI(vlen)
+  real(r8) :: QSI(vlen)
+!!  real(r8) :: tau
+  integer  :: i
 
-  stend = 0._r8
-  qvtend = 0._r8
-  qitend = 0._r8
-  nitend = 0._r8
+  do i = 1, vlen
+     stend(i)  = 0._r8
+     qvtend(i) = 0._r8
+     qitend(i) = 0._r8
+     nitend(i) = 0._r8
+  end do
 
-!	calculate qsati from t,p,q
+! calculate qsati from t,p,q
+  call wv_sat_qsat_ice_vect(t, p, ESI, QSI, vlen)
 
-  call wv_sat_qsat_ice(t, p, ESI, QSI)
+  do i = 1, vlen
+     if (naai(i) > 1.e-18_r8 .and. qv(i) > QSI(i)) then
 
-  if (naai > 1.e-18_r8 .and. qv > QSI) then
+        qitend(i) = (qv(i)-QSI(i))/deltat !* exp(-tau/deltat)
+        qvtend(i) = 0._r8 - qitend(i)
+        stend(i)  = qitend(i) * xxls      ! moist static energy tend...[J/kg/s] !
+   
+        ! if ice exists (more than 1 L-1) and there is condensation, do not add to number (= growth), else, add 10um ice
+        if (ni(i) < 1.e3_r8 .and. (qi(i)+qitend(i)*deltat) > 1.e-18_r8) then
+           nitend(i) = nitend(i) + 3._r8 * qitend(i)/(4._r8*3.14_r8* 10.e-6_r8**3*997._r8)
+        end if
 
-
-     qitend = (qv-QSI)/deltat !* exp(-tau/deltat)
-     qvtend = 0._r8 - qitend
-     stend  = qitend * xxls    ! moist static energy tend...[J/kg/s] !
-
-
- ! if ice exists (more than 1 L-1) and there is condensation, do not add to number (= growth), else, add 10um ice
-     if (ni < 1.e3_r8 .and. (qi+qitend*deltat) > 1.e-18_r8) then
-        nitend = nitend + 3._r8 * qitend/(4._r8*3.14_r8* 10.e-6_r8**3*997._r8)
-     endif
-
-  endif
+     end if
+  end do
 
 end subroutine ice_macro_tend
 

--- a/src/physics/cam/convect_shallow.F90
+++ b/src/physics/cam/convect_shallow.F90
@@ -779,8 +779,11 @@
    slv_preCu(:ncol,:pver) = sl_preCu(:ncol,:pver) * ( 1._r8 + zvir * qt_preCu(:ncol,:pver) )
 
    t_preCu(:ncol,:)       = state1%t(:ncol,:pver)
-   call qsat(state1%t(:ncol,:), state1%pmid(:ncol,:), &
-        tem2(:ncol,:), ftem(:ncol,:))
+   do k = 1, pver
+      do i = 1, ncol
+         call qsat(state1%t(i,k), state1%pmid(i,k), tem2(i,k), ftem(i,k))
+      end do
+   end do
    ftem_preCu(:ncol,:)    = state1%q(:ncol,:,1) / ftem(:ncol,:) * 100._r8
 
    call outfld( 'qt_pre_Cu      ', qt_preCu               , pcols, lchnk )
@@ -810,8 +813,11 @@
                                               + state1%q(:ncol,:pver,ixcldice)
    slv(:ncol,:pver) = sl(:ncol,:pver) * ( 1._r8 + zvir * qt(:ncol,:pver) )
 
-   call qsat(state1%t(:ncol,:), state1%pmid(:ncol,:), &
-        tem2(:ncol,:), ftem(:ncol,:))
+   do k = 1, pver
+      do i = 1, ncol
+         call qsat(state1%t(i,k), state1%pmid(i,k), tem2(i,k), ftem(i,k))
+      end do
+   end do
    ftem(:ncol,:)    = state1%q(:ncol,:,1) / ftem(:ncol,:) * 100._r8
 
    call outfld( 'qt_aft_Cu      ', qt                     , pcols, lchnk )

--- a/src/physics/cam/convect_shallow.F90
+++ b/src/physics/cam/convect_shallow.F90
@@ -779,9 +779,7 @@
    slv_preCu(:ncol,:pver) = sl_preCu(:ncol,:pver) * ( 1._r8 + zvir * qt_preCu(:ncol,:pver) )
 
    t_preCu(:ncol,:)       = state1%t(:ncol,:pver)
-   do k = 1, pver
-      call qsat(state1%t(1:ncol,k), state1%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
-   end do
+   call qsat(state1%t(1:ncol,1:pver), state1%pmid(1:ncol,1:pver), tem2(1:ncol,1:pver), ftem(1:ncol,1:pver), ncol, pver)
    ftem_preCu(:ncol,:)    = state1%q(:ncol,:,1) / ftem(:ncol,:) * 100._r8
 
    call outfld( 'qt_pre_Cu      ', qt_preCu               , pcols, lchnk )
@@ -811,9 +809,7 @@
                                               + state1%q(:ncol,:pver,ixcldice)
    slv(:ncol,:pver) = sl(:ncol,:pver) * ( 1._r8 + zvir * qt(:ncol,:pver) )
 
-   do k = 1, pver
-      call qsat(state1%t(1:ncol,k), state1%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
-   end do
+   call qsat(state1%t(1:ncol,1:pver), state1%pmid(1:ncol,1:pver), tem2(1:ncol,1:pver), ftem(1:ncol,1:pver), ncol, pver)
    ftem(:ncol,:)    = state1%q(:ncol,:,1) / ftem(:ncol,:) * 100._r8
 
    call outfld( 'qt_aft_Cu      ', qt                     , pcols, lchnk )

--- a/src/physics/cam/convect_shallow.F90
+++ b/src/physics/cam/convect_shallow.F90
@@ -779,7 +779,9 @@
    slv_preCu(:ncol,:pver) = sl_preCu(:ncol,:pver) * ( 1._r8 + zvir * qt_preCu(:ncol,:pver) )
 
    t_preCu(:ncol,:)       = state1%t(:ncol,:pver)
-   call qsat(state1%t(1:ncol,1:pver), state1%pmid(1:ncol,1:pver), tem2(1:ncol,1:pver), ftem(1:ncol,1:pver), ncol, pver)
+   do k = 1, pver
+      call qsat(state1%t(1:ncol,k), state1%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
+   end do
    ftem_preCu(:ncol,:)    = state1%q(:ncol,:,1) / ftem(:ncol,:) * 100._r8
 
    call outfld( 'qt_pre_Cu      ', qt_preCu               , pcols, lchnk )
@@ -809,7 +811,9 @@
                                               + state1%q(:ncol,:pver,ixcldice)
    slv(:ncol,:pver) = sl(:ncol,:pver) * ( 1._r8 + zvir * qt(:ncol,:pver) )
 
-   call qsat(state1%t(1:ncol,1:pver), state1%pmid(1:ncol,1:pver), tem2(1:ncol,1:pver), ftem(1:ncol,1:pver), ncol, pver)
+   do k = 1, pver
+      call qsat(state1%t(1:ncol,k), state1%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
+   end do
    ftem(:ncol,:)    = state1%q(:ncol,:,1) / ftem(:ncol,:) * 100._r8
 
    call outfld( 'qt_aft_Cu      ', qt                     , pcols, lchnk )

--- a/src/physics/cam/convect_shallow.F90
+++ b/src/physics/cam/convect_shallow.F90
@@ -780,9 +780,7 @@
 
    t_preCu(:ncol,:)       = state1%t(:ncol,:pver)
    do k = 1, pver
-      do i = 1, ncol
-         call qsat(state1%t(i,k), state1%pmid(i,k), tem2(i,k), ftem(i,k))
-      end do
+      call qsat(state1%t(1:ncol,k), state1%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
    end do
    ftem_preCu(:ncol,:)    = state1%q(:ncol,:,1) / ftem(:ncol,:) * 100._r8
 
@@ -814,9 +812,7 @@
    slv(:ncol,:pver) = sl(:ncol,:pver) * ( 1._r8 + zvir * qt(:ncol,:pver) )
 
    do k = 1, pver
-      do i = 1, ncol
-         call qsat(state1%t(i,k), state1%pmid(i,k), tem2(i,k), ftem(i,k))
-      end do
+      call qsat(state1%t(1:ncol,k), state1%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
    end do
    ftem(:ncol,:)    = state1%q(:ncol,:,1) / ftem(:ncol,:) * 100._r8
 

--- a/src/physics/cam/cospsimulator_intr.F90
+++ b/src/physics/cam/cospsimulator_intr.F90
@@ -1856,9 +1856,11 @@ CONTAINS
     
     ! 2) rh - relative_humidity_liquid_water (%)
     ! calculate from CAM q and t using CAM built-in functions
-    call qsat_water(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), &
-         es(1:ncol,1:pver), qs(1:ncol,1:pver))
-    
+    do k = 1, pver
+       do i = 1, ncol 
+          call qsat_water(state%t(i,k), state%pmid(i,k), es(i,k), qs(i,k))
+       end do 
+    end do
     ! initialize rh
     rh(1:ncol,1:pver)=0._r8
     

--- a/src/physics/cam/cospsimulator_intr.F90
+++ b/src/physics/cam/cospsimulator_intr.F90
@@ -1856,9 +1856,7 @@ CONTAINS
     
     ! 2) rh - relative_humidity_liquid_water (%)
     ! calculate from CAM q and t using CAM built-in functions
-    do k = 1, pver
-       call qsat_water(state%t(1:ncol,k), state%pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
-    end do
+    call qsat_water(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), es(1:ncol,1:pver), qs(1:ncol,1:pver), ncol, pver)
     ! initialize rh
     rh(1:ncol,1:pver)=0._r8
     

--- a/src/physics/cam/cospsimulator_intr.F90
+++ b/src/physics/cam/cospsimulator_intr.F90
@@ -1857,9 +1857,7 @@ CONTAINS
     ! 2) rh - relative_humidity_liquid_water (%)
     ! calculate from CAM q and t using CAM built-in functions
     do k = 1, pver
-       do i = 1, ncol 
-          call qsat_water(state%t(i,k), state%pmid(i,k), es(i,k), qs(i,k))
-       end do 
+       call qsat_water(state%t(1:ncol,k), state%pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
     end do
     ! initialize rh
     rh(1:ncol,1:pver)=0._r8

--- a/src/physics/cam/cospsimulator_intr.F90
+++ b/src/physics/cam/cospsimulator_intr.F90
@@ -1856,7 +1856,9 @@ CONTAINS
     
     ! 2) rh - relative_humidity_liquid_water (%)
     ! calculate from CAM q and t using CAM built-in functions
-    call qsat_water(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), es(1:ncol,1:pver), qs(1:ncol,1:pver), ncol, pver)
+    do k = 1, pver
+       call qsat_water(state%t(1:ncol,k), state%pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
+    end do
     ! initialize rh
     rh(1:ncol,1:pver)=0._r8
     

--- a/src/physics/cam/eddy_diff.F90
+++ b/src/physics/cam/eddy_diff.F90
@@ -503,8 +503,8 @@
     ! Note that 'ntop_turb = 1', 'nbot_turb = pver'
 
     do k = ntop_turb, nbot_turb
-       call qsat( t(:ncol,k), pmid(:ncol,k), es(:ncol,k), qs(:ncol,k), gam=gam(:ncol,k))
        do i = 1, ncol
+          call qsat( t(i,k), pmid(i,k), es(i,k), qs(i,k), gam=gam(i,k))
           qt(i,k)  = qv(i,k) + ql(i,k) + qi(i,k) 
           sl(i,k)  = cpair * t(i,k) + g * z(i,k) - latvap * ql(i,k) - latsub * qi(i,k)
           slv(i,k) = sl(i,k) * ( 1._r8 + zvir * qt(i,k) )

--- a/src/physics/cam/eddy_diff.F90
+++ b/src/physics/cam/eddy_diff.F90
@@ -501,11 +501,8 @@
 
     ! Calculate conservative scalars (qt,sl,slv) and buoyancy coefficients at the layer mid-points.
     ! Note that 'ntop_turb = 1', 'nbot_turb = pver'
-
-    call qsat( t(1:ncol,ntop_turb:nbot_turb), pmid(1:ncol,ntop_turb:nbot_turb), &
-               es(1:ncol,ntop_turb:nbot_turb), qs(1:ncol,ntop_turb:nbot_turb), ncol, &
-               nbot_turb-ntop_turb+1, gam=gam(1:ncol,ntop_turb:nbot_turb))
     do k = ntop_turb, nbot_turb
+       call qsat( t(1:ncol,k), pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol, gam=gam(1:ncol,k))
        do i = 1, ncol
           qt(i,k)  = qv(i,k) + ql(i,k) + qi(i,k) 
           sl(i,k)  = cpair * t(i,k) + g * z(i,k) - latvap * ql(i,k) - latsub * qi(i,k)

--- a/src/physics/cam/eddy_diff.F90
+++ b/src/physics/cam/eddy_diff.F90
@@ -503,8 +503,8 @@
     ! Note that 'ntop_turb = 1', 'nbot_turb = pver'
 
     do k = ntop_turb, nbot_turb
+       call qsat( t(1:ncol,k), pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol, gam=gam(1:ncol,k))
        do i = 1, ncol
-          call qsat( t(i,k), pmid(i,k), es(i,k), qs(i,k), gam=gam(i,k))
           qt(i,k)  = qv(i,k) + ql(i,k) + qi(i,k) 
           sl(i,k)  = cpair * t(i,k) + g * z(i,k) - latvap * ql(i,k) - latsub * qi(i,k)
           slv(i,k) = sl(i,k) * ( 1._r8 + zvir * qt(i,k) )

--- a/src/physics/cam/eddy_diff.F90
+++ b/src/physics/cam/eddy_diff.F90
@@ -502,8 +502,10 @@
     ! Calculate conservative scalars (qt,sl,slv) and buoyancy coefficients at the layer mid-points.
     ! Note that 'ntop_turb = 1', 'nbot_turb = pver'
 
+    call qsat( t(1:ncol,ntop_turb:nbot_turb), pmid(1:ncol,ntop_turb:nbot_turb), &
+               es(1:ncol,ntop_turb:nbot_turb), qs(1:ncol,ntop_turb:nbot_turb), ncol, &
+               nbot_turb-ntop_turb+1, gam=gam(1:ncol,ntop_turb:nbot_turb))
     do k = ntop_turb, nbot_turb
-       call qsat( t(1:ncol,k), pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol, gam=gam(1:ncol,k))
        do i = 1, ncol
           qt(i,k)  = qv(i,k) + ql(i,k) + qi(i,k) 
           sl(i,k)  = cpair * t(i,k) + g * z(i,k) - latvap * ql(i,k) - latsub * qi(i,k)

--- a/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -23,7 +23,7 @@ use physics_buffer, only: pbuf_add_field, dtype_r8, pbuf_old_tim_idx, &
 use cam_history,    only: addfld, add_default, outfld
 
 use ref_pres,       only: top_lev => trop_cloud_top_lev
-use wv_saturation,  only: svp_water, svp_ice
+use wv_saturation,  only: svp_water_vect, svp_ice_vect
 
 use cam_logfile,    only: iulog
 use error_messages, only: handle_errmsg, alloc_err
@@ -608,7 +608,7 @@ subroutine hetfrz_classnuc_cam_calc( &
 
    real(r8) :: fn_cloudborne_aer_num(pcols,pver,3)
 
-
+   real(r8) :: esi(pcols,pver), esl(pcols,pver) 
    real(r8) :: con1, r3lx, supersatice
 
    real(r8) :: qcic
@@ -773,6 +773,9 @@ subroutine hetfrz_classnuc_cam_calc( &
    nicnt_dst(:,:) = 0._r8
    nidep_dst(:,:) = 0._r8
 
+   call svp_water_vect(t(1:ncol,top_lev:pver), esl(1:ncol,top_lev:pver), ncol*(pver-top_lev+1))
+   call svp_ice_vect(t(1:ncol,top_lev:pver), esi(1:ncol,top_lev:pver), ncol*(pver-top_lev+1))
+
    do i = 1, ncol
       do k = top_lev, pver
 
@@ -783,7 +786,7 @@ subroutine hetfrz_classnuc_cam_calc( &
             con1 = 1._r8/(1.333_r8*pi)**0.333_r8
             r3lx = con1*(rho(i,k)*qcic/(rhoh2o*max(ncic*rho(i,k), 1.0e6_r8)))**0.333_r8 ! in m
             r3lx = max(4.e-6_r8, r3lx)
-            supersatice = svp_water(t(i,k))/svp_ice(t(i,k))
+            supersatice = esl(i,k)/esi(i,k)
 
             fn(1) = factnum(i,k,mode_accum_idx)  ! bc accumulation mode
             if (nmodes == MAM3_nmodes .or. nmodes == MAM4_nmodes) then

--- a/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -774,8 +774,8 @@ subroutine hetfrz_classnuc_cam_calc( &
    nidep_dst(:,:) = 0._r8
 
    do k = top_lev, pver
-      call svp_water_vect(t(1:ncol), esl(1:ncol), ncol)
-      call svp_ice_vect(t(1:ncol), esi(1:ncol), ncol)
+      call svp_water_vect(t(1:ncol,k), esl(1:ncol), ncol)
+      call svp_ice_vect(t(1:ncol,k), esi(1:ncol), ncol)
       do i = 1, ncol
 
          if (t(i,k) > 235.15_r8 .and. t(i,k) < 269.15_r8) then

--- a/src/physics/cam/hetfrz_classnuc_cam.F90
+++ b/src/physics/cam/hetfrz_classnuc_cam.F90
@@ -608,7 +608,7 @@ subroutine hetfrz_classnuc_cam_calc( &
 
    real(r8) :: fn_cloudborne_aer_num(pcols,pver,3)
 
-   real(r8) :: esi(pcols,pver), esl(pcols,pver) 
+   real(r8) :: esi(pcols), esl(pcols) 
    real(r8) :: con1, r3lx, supersatice
 
    real(r8) :: qcic
@@ -773,11 +773,10 @@ subroutine hetfrz_classnuc_cam_calc( &
    nicnt_dst(:,:) = 0._r8
    nidep_dst(:,:) = 0._r8
 
-   call svp_water_vect(t(1:ncol,top_lev:pver), esl(1:ncol,top_lev:pver), ncol*(pver-top_lev+1))
-   call svp_ice_vect(t(1:ncol,top_lev:pver), esi(1:ncol,top_lev:pver), ncol*(pver-top_lev+1))
-
-   do i = 1, ncol
-      do k = top_lev, pver
+   do k = top_lev, pver
+      call svp_water_vect(t(1:ncol), esl(1:ncol), ncol)
+      call svp_ice_vect(t(1:ncol), esi(1:ncol), ncol)
+      do i = 1, ncol
 
          if (t(i,k) > 235.15_r8 .and. t(i,k) < 269.15_r8) then
             qcic = min(qc(i,k)/lcldm(i,k), 5.e-3_r8)
@@ -786,7 +785,7 @@ subroutine hetfrz_classnuc_cam_calc( &
             con1 = 1._r8/(1.333_r8*pi)**0.333_r8
             r3lx = con1*(rho(i,k)*qcic/(rhoh2o*max(ncic*rho(i,k), 1.0e6_r8)))**0.333_r8 ! in m
             r3lx = max(4.e-6_r8, r3lx)
-            supersatice = esl(i,k)/esi(i,k)
+            supersatice = esl(i)/esi(i)
 
             fn(1) = factnum(i,k,mode_accum_idx)  ! bc accumulation mode
             if (nmodes == MAM3_nmodes .or. nmodes == MAM4_nmodes) then

--- a/src/physics/cam/hk_conv.F90
+++ b/src/physics/cam/hk_conv.F90
@@ -434,9 +434,13 @@ subroutine cmfmca(lchnk   ,ncol    , &
 !
 ! Compute sb,hb,shbs,hbs
 !
-   call qsat(tb(:ncol,limcnv:pver), pmid(:ncol,limcnv:pver), &
-        estemp(:ncol,limcnv:pver), shbs(:ncol,limcnv:pver), &
-        gam=gam(:ncol,limcnv:pver))
+   do k = limcnv,pver
+      do i = 1,ncol
+         call qsat(tb(i,k), pmid(i,k), &
+              estemp(i,k), shbs(i,k), &
+              gam=gam(i,k))
+      end do
+   end do
 !
    do k=limcnv,pver
       do i=1,ncol
@@ -908,8 +912,10 @@ subroutine cmfmca(lchnk   ,ncol    , &
                      vtemp2(ii     ) = pmid(i,k)
                      vtemp2(ii+len1) = pmid(i,k-1)
                   end do
-                  call qsat(vtemp1(:2*len1), vtemp2(:2*len1), &
-                       vtemp5(:2*len1), vtemp3(:2*len1), gam=vtemp4(:2*len1))
+                  do ii=1,2*len1
+                     call qsat(vtemp1(ii), vtemp2(ii), &
+                          vtemp5(ii), vtemp3(ii), gam=vtemp4(ii))
+                  end do
                   do ii=1,len1
                      i = indx1(ii)
                      shbs(i,k  ) = vtemp3(ii     )

--- a/src/physics/cam/hk_conv.F90
+++ b/src/physics/cam/hk_conv.F90
@@ -434,11 +434,9 @@ subroutine cmfmca(lchnk   ,ncol    , &
 !
 ! Compute sb,hb,shbs,hbs
 !
-   do k = limcnv,pver
-      call qsat(tb(1:ncol,k), pmid(1:ncol,k), &
-           estemp(1:ncol,k), shbs(1:ncol,k), ncol, &
-           gam=gam(1:ncol,k))
-   end do
+   call qsat(tb(1:ncol,limcnv:pver), pmid(1:ncol,limcnv:pver), &
+        estemp(1:ncol,limcnv:pver), shbs(1:ncol,limcnv:pver),  &
+        ncol, pver-limcnv+1, gam=gam(1:ncol,limcnv:pver))
 !
    do k=limcnv,pver
       do i=1,ncol

--- a/src/physics/cam/hk_conv.F90
+++ b/src/physics/cam/hk_conv.F90
@@ -435,11 +435,9 @@ subroutine cmfmca(lchnk   ,ncol    , &
 ! Compute sb,hb,shbs,hbs
 !
    do k = limcnv,pver
-      do i = 1,ncol
-         call qsat(tb(i,k), pmid(i,k), &
-              estemp(i,k), shbs(i,k), &
-              gam=gam(i,k))
-      end do
+      call qsat(tb(1:ncol,k), pmid(1:ncol,k), &
+           estemp(1:ncol,k), shbs(1:ncol,k), ncol, &
+           gam=gam(1:ncol,k))
    end do
 !
    do k=limcnv,pver
@@ -912,10 +910,8 @@ subroutine cmfmca(lchnk   ,ncol    , &
                      vtemp2(ii     ) = pmid(i,k)
                      vtemp2(ii+len1) = pmid(i,k-1)
                   end do
-                  do ii=1,2*len1
-                     call qsat(vtemp1(ii), vtemp2(ii), &
-                          vtemp5(ii), vtemp3(ii), gam=vtemp4(ii))
-                  end do
+                  call qsat(vtemp1(1:2*len1), vtemp2(1:2*len1), &
+                            vtemp5(1:2*len1), vtemp3(1:2*len1), 2*len1, gam=vtemp4(1:2*len1))
                   do ii=1,len1
                      i = indx1(ii)
                      shbs(i,k  ) = vtemp3(ii     )

--- a/src/physics/cam/hk_conv.F90
+++ b/src/physics/cam/hk_conv.F90
@@ -434,9 +434,11 @@ subroutine cmfmca(lchnk   ,ncol    , &
 !
 ! Compute sb,hb,shbs,hbs
 !
-   call qsat(tb(1:ncol,limcnv:pver), pmid(1:ncol,limcnv:pver), &
-        estemp(1:ncol,limcnv:pver), shbs(1:ncol,limcnv:pver),  &
-        ncol, pver-limcnv+1, gam=gam(1:ncol,limcnv:pver))
+   do k = limcnv,pver
+      call qsat(tb(1:ncol,k), pmid(1:ncol,k), &
+           estemp(1:ncol,k), shbs(1:ncol,k), ncol, &
+           gam=gam(1:ncol,k))
+   end do
 !
    do k=limcnv,pver
       do i=1,ncol

--- a/src/physics/cam/macrop_driver.F90
+++ b/src/physics/cam/macrop_driver.F90
@@ -1128,7 +1128,7 @@ end subroutine macrop_driver_tend
 ! this issue is investigated in CLUBB, this routine will enfornce a 
 ! maximum RHliq of 1 everywhere in the atmosphere. Any excess water will
 ! be converted into cloud drops.
-elemental subroutine liquid_macro_tend(npccn,t,p,qv,qc,nc,xxlv,deltat,stend,qvtend,qctend,nctend)
+subroutine liquid_macro_tend(npccn,t,p,qv,qc,nc,xxlv,deltat,stend,qvtend,qctend,nctend)
 
   use wv_sat_methods, only: wv_sat_qsat_ice, wv_sat_qsat_water
   use micro_mg_utils, only: rhow

--- a/src/physics/cam/macrop_driver.F90
+++ b/src/physics/cam/macrop_driver.F90
@@ -1128,55 +1128,61 @@ end subroutine macrop_driver_tend
 ! this issue is investigated in CLUBB, this routine will enfornce a 
 ! maximum RHliq of 1 everywhere in the atmosphere. Any excess water will
 ! be converted into cloud drops.
-subroutine liquid_macro_tend(npccn,t,p,qv,qc,nc,xxlv,deltat,stend,qvtend,qctend,nctend)
+subroutine liquid_macro_tend(npccn,t,p,qv,qc,nc,xxlv,deltat,stend,qvtend,qctend,nctend,vlen)
 
-  use wv_sat_methods, only: wv_sat_qsat_ice, wv_sat_qsat_water
+  use wv_sat_methods, only: wv_sat_qsat_ice_vect, wv_sat_qsat_water_vect
   use micro_mg_utils, only: rhow
   use physconst,      only: rair
   use cldfrc2m,       only: rhmini_const, rhmaxi_const
 
-  real(r8), intent(in)  :: npccn  !Activated number of cloud condensation nuclei 
-  real(r8), intent(in)  :: t      !temperature (k)
-  real(r8), intent(in)  :: p      !pressure (pa)
-  real(r8), intent(in)  :: qv     !water vapor mixing ratio
-  real(r8), intent(in)  :: qc     !liquid mixing ratio
-  real(r8), intent(in)  :: nc     !liquid number concentration
-  real(r8), intent(in)  :: xxlv   !latent heat of vaporization
-  real(r8), intent(in)  :: deltat !timestep
-  real(r8), intent(out) :: stend  ! 'temperature' tendency 
-  real(r8), intent(out) :: qvtend !vapor tendency
-  real(r8), intent(out) :: qctend !liquid mass tendency
-  real(r8), intent(out) :: nctend !liquid number tendency 
+  integer,                   intent(in)  :: vlen
+  real(r8), dimension(vlen), intent(in)  :: npccn  !Activated number of cloud condensation nuclei 
+  real(r8), dimension(vlen), intent(in)  :: t      !temperature (k)
+  real(r8), dimension(vlen), intent(in)  :: p      !pressure (pa)
+  real(r8), dimension(vlen), intent(in)  :: qv     !water vapor mixing ratio
+  real(r8), dimension(vlen), intent(in)  :: qc     !liquid mixing ratio
+  real(r8), dimension(vlen), intent(in)  :: nc     !liquid number concentration
+  real(r8),                  intent(in)  :: xxlv   !latent heat of vaporization
+  real(r8),                  intent(in)  :: deltat !timestep
+  real(r8), dimension(vlen), intent(out) :: stend  ! 'temperature' tendency 
+  real(r8), dimension(vlen), intent(out) :: qvtend !vapor tendency
+  real(r8), dimension(vlen), intent(out) :: qctend !liquid mass tendency
+  real(r8), dimension(vlen), intent(out) :: nctend !liquid number tendency 
 
+  real(r8) :: ESL(vlen)
+  real(r8) :: QSL(vlen)
+  integer  :: i
 
-  real(r8) :: ESL
-  real(r8) :: QSL
-
-  stend = 0._r8
-  qvtend = 0._r8
-  qctend = 0._r8
-  nctend = 0._r8
+  do i = 1, vlen
+     stend(i) = 0._r8
+     qvtend(i) = 0._r8
+     qctend(i) = 0._r8
+     nctend(i) = 0._r8
+  end do
 
   ! calculate qsatl from t,p,q
-  call wv_sat_qsat_water(t, p, ESL, QSL)
+  call wv_sat_qsat_water_vect(t, p, ESL, QSL, vlen)
 
-  ! Don't allow supersaturation with respect to liquid.
-  if (qv.gt.QSL) then
+  do i = 1, vlen
+     ! Don't allow supersaturation with respect to liquid.
+     if (qv(i).gt.QSL(i)) then
+   
+        qctend(i) = (qv(i) - QSL(i)) / deltat
+        qvtend(i) = 0._r8 - qctend(i)
+        stend(i)  = qctend(i) * xxlv    ! moist static energy tend...[J/kg/s] !
+   
+        ! If drops  exists (more than 1 L-1) and there is condensation,
+        ! do not add to number (= growth), otherwise  add 6um drops.
+        !
+        ! This is somewhat arbitrary, but ensures that some reasonable droplet
+        ! size is create to remove the excess water. This could be enhanced to
+        ! look at npccn, but ideally this entire routine should go away.
+        if (nc(i)*p(i)/rair/t(i).lt.1e3_r8.and.(qc(i)+qctend(i)*deltat).gt.1e-18_r8) then
+           nctend(i) = nctend(i) + 3._r8 * qctend(i)/(4._r8*3.14_r8*6.e-6_r8**3*rhow)
+        end if
+     end if
+  end do
 
-     qctend = (qv - QSL) / deltat
-     qvtend = 0._r8 - qctend
-     stend  = qctend * xxlv    ! moist static energy tend...[J/kg/s] !
-
-     ! If drops  exists (more than 1 L-1) and there is condensation,
-     ! do not add to number (= growth), otherwise  add 6um drops.
-     !
-     ! This is somewhat arbitrary, but ensures that some reasonable droplet
-     ! size is create to remove the excess water. This could be enhanced to
-     ! look at npccn, but ideally this entire routine should go away.
-     if (nc*p/rair/t.lt.1e3_r8.and.(qc+qctend*deltat).gt.1e-18_r8) then
-        nctend = nctend + 3._r8 * qctend/(4._r8*3.14_r8*6.e-6_r8**3*rhow)
-     endif
-  endif
 end subroutine liquid_macro_tend
 
 end module macrop_driver

--- a/src/physics/cam/micro_mg_cam.F90
+++ b/src/physics/cam/micro_mg_cam.F90
@@ -3087,9 +3087,11 @@ subroutine micro_mg_cam_tend_pack(state, ptend, dtime, pbuf, mgncol, mgcols, nle
 
    ncic_grid = 1.e8_r8
 
-   call size_dist_param_liq(mg_liq_props, icwmrst_grid(:ngrdcol,top_lev:), &
-        ncic_grid(:ngrdcol,top_lev:), rho_grid(:ngrdcol,top_lev:), &
-        mu_grid(:ngrdcol,top_lev:), lambdac_grid(:ngrdcol,top_lev:), ngrdcol, (nlev-top_lev+1))
+   do k = top_lev, nlev
+      call size_dist_param_liq(mg_liq_props, icwmrst_grid(:ngrdcol,k), &
+           ncic_grid(:ngrdcol,k), rho_grid(:ngrdcol,k), &
+           mu_grid(:ngrdcol,k), lambdac_grid(:ngrdcol,k), ngrdcol)
+   end do
 
    where (icwmrst_grid(:ngrdcol,top_lev:) > qsmall)
       rel_fn_grid(:ngrdcol,top_lev:) = &
@@ -3107,9 +3109,11 @@ subroutine micro_mg_cam_tend_pack(state, ptend, dtime, pbuf, mgncol, mgcols, nle
    ncic_grid(:ngrdcol,top_lev:) = nc_grid(:ngrdcol,top_lev:) / &
         max(mincld,liqcldf_grid(:ngrdcol,top_lev:))
 
-   call size_dist_param_liq(mg_liq_props, icwmrst_grid(:ngrdcol,top_lev:), &
-        ncic_grid(:ngrdcol,top_lev:), rho_grid(:ngrdcol,top_lev:), &
-        mu_grid(:ngrdcol,top_lev:), lambdac_grid(:ngrdcol,top_lev:), ngrdcol, (nlev-top_lev+1))
+   do k = top_lev, nlev
+      call size_dist_param_liq(mg_liq_props, icwmrst_grid(:ngrdcol,k), &
+           ncic_grid(:ngrdcol,k), rho_grid(:ngrdcol,k), &
+           mu_grid(:ngrdcol,k), lambdac_grid(:ngrdcol,k), ngrdcol)
+   end do
 
    where (icwmrst_grid(:ngrdcol,top_lev:) >= qsmall)
       rel_grid(:ngrdcol,top_lev:) = &
@@ -3205,8 +3209,10 @@ subroutine micro_mg_cam_tend_pack(state, ptend, dtime, pbuf, mgncol, mgcols, nle
    niic_grid(:ngrdcol,top_lev:) = ni_grid(:ngrdcol,top_lev:) / &
         max(mincld,icecldf_grid(:ngrdcol,top_lev:))
 
-   call size_dist_param_basic(mg_ice_props, icimrst_grid(:ngrdcol,top_lev:), &
-        niic_grid(:ngrdcol,top_lev:), rei_grid(:ngrdcol,top_lev:), ngrdcol, (nlev-top_lev+1))
+   do k = top_lev, nlev
+      call size_dist_param_basic(mg_ice_props, icimrst_grid(:ngrdcol,k), &
+           niic_grid(:ngrdcol,k), rei_grid(:ngrdcol,k), ngrdcol)
+   end do
 
    where (icimrst_grid(:ngrdcol,top_lev:) >= qsmall)
       rei_grid(:ngrdcol,top_lev:) = 1.5_r8/rei_grid(:ngrdcol,top_lev:) &

--- a/src/physics/cam/micro_mg_cam.F90
+++ b/src/physics/cam/micro_mg_cam.F90
@@ -1389,7 +1389,7 @@ end subroutine micro_mg_cam_tend
 
 subroutine micro_mg_cam_tend_pack(state, ptend, dtime, pbuf, mgncol, mgcols, nlev)
 
-   use micro_mg_utils, only: size_dist_param_basic_vect, size_dist_param_liq_vect, &
+   use micro_mg_utils, only: size_dist_param_basic, size_dist_param_liq, &
         mg_liq_props, mg_ice_props, avg_diameter, rhoi, rhosn, rhow, rhows, &
         mg_graupel_props, rhog, &
         qsmall, mincld
@@ -3087,9 +3087,9 @@ subroutine micro_mg_cam_tend_pack(state, ptend, dtime, pbuf, mgncol, mgcols, nle
 
    ncic_grid = 1.e8_r8
 
-   call size_dist_param_liq_vect(mg_liq_props, icwmrst_grid(:ngrdcol,top_lev:), &
+   call size_dist_param_liq(mg_liq_props, icwmrst_grid(:ngrdcol,top_lev:), &
         ncic_grid(:ngrdcol,top_lev:), rho_grid(:ngrdcol,top_lev:), &
-        mu_grid(:ngrdcol,top_lev:), lambdac_grid(:ngrdcol,top_lev:), ngrdcol*(nlev-top_lev+1))
+        mu_grid(:ngrdcol,top_lev:), lambdac_grid(:ngrdcol,top_lev:), ngrdcol, (nlev-top_lev+1))
 
    where (icwmrst_grid(:ngrdcol,top_lev:) > qsmall)
       rel_fn_grid(:ngrdcol,top_lev:) = &
@@ -3107,9 +3107,9 @@ subroutine micro_mg_cam_tend_pack(state, ptend, dtime, pbuf, mgncol, mgcols, nle
    ncic_grid(:ngrdcol,top_lev:) = nc_grid(:ngrdcol,top_lev:) / &
         max(mincld,liqcldf_grid(:ngrdcol,top_lev:))
 
-   call size_dist_param_liq_vect(mg_liq_props, icwmrst_grid(:ngrdcol,top_lev:), &
+   call size_dist_param_liq(mg_liq_props, icwmrst_grid(:ngrdcol,top_lev:), &
         ncic_grid(:ngrdcol,top_lev:), rho_grid(:ngrdcol,top_lev:), &
-        mu_grid(:ngrdcol,top_lev:), lambdac_grid(:ngrdcol,top_lev:), ngrdcol*(nlev-top_lev+1))
+        mu_grid(:ngrdcol,top_lev:), lambdac_grid(:ngrdcol,top_lev:), ngrdcol, (nlev-top_lev+1))
 
    where (icwmrst_grid(:ngrdcol,top_lev:) >= qsmall)
       rel_grid(:ngrdcol,top_lev:) = &
@@ -3205,8 +3205,8 @@ subroutine micro_mg_cam_tend_pack(state, ptend, dtime, pbuf, mgncol, mgcols, nle
    niic_grid(:ngrdcol,top_lev:) = ni_grid(:ngrdcol,top_lev:) / &
         max(mincld,icecldf_grid(:ngrdcol,top_lev:))
 
-   call size_dist_param_basic_vect(mg_ice_props, icimrst_grid(:ngrdcol,top_lev:), &
-        niic_grid(:ngrdcol,top_lev:), rei_grid(:ngrdcol,top_lev:), ngrdcol*(nlev-top_lev+1))
+   call size_dist_param_basic(mg_ice_props, icimrst_grid(:ngrdcol,top_lev:), &
+        niic_grid(:ngrdcol,top_lev:), rei_grid(:ngrdcol,top_lev:), ngrdcol, (nlev-top_lev+1))
 
    where (icimrst_grid(:ngrdcol,top_lev:) >= qsmall)
       rei_grid(:ngrdcol,top_lev:) = 1.5_r8/rei_grid(:ngrdcol,top_lev:) &

--- a/src/physics/cam/micro_mg_cam.F90
+++ b/src/physics/cam/micro_mg_cam.F90
@@ -1389,7 +1389,7 @@ end subroutine micro_mg_cam_tend
 
 subroutine micro_mg_cam_tend_pack(state, ptend, dtime, pbuf, mgncol, mgcols, nlev)
 
-   use micro_mg_utils, only: size_dist_param_basic, size_dist_param_liq, &
+   use micro_mg_utils, only: size_dist_param_basic_vect, size_dist_param_liq_vect, &
         mg_liq_props, mg_ice_props, avg_diameter, rhoi, rhosn, rhow, rhows, &
         mg_graupel_props, rhog, &
         qsmall, mincld
@@ -3087,9 +3087,9 @@ subroutine micro_mg_cam_tend_pack(state, ptend, dtime, pbuf, mgncol, mgcols, nle
 
    ncic_grid = 1.e8_r8
 
-   call size_dist_param_liq(mg_liq_props, icwmrst_grid(:ngrdcol,top_lev:), &
+   call size_dist_param_liq_vect(mg_liq_props, icwmrst_grid(:ngrdcol,top_lev:), &
         ncic_grid(:ngrdcol,top_lev:), rho_grid(:ngrdcol,top_lev:), &
-        mu_grid(:ngrdcol,top_lev:), lambdac_grid(:ngrdcol,top_lev:))
+        mu_grid(:ngrdcol,top_lev:), lambdac_grid(:ngrdcol,top_lev:), ngrdcol*(nlev-top_lev+1))
 
    where (icwmrst_grid(:ngrdcol,top_lev:) > qsmall)
       rel_fn_grid(:ngrdcol,top_lev:) = &
@@ -3107,9 +3107,9 @@ subroutine micro_mg_cam_tend_pack(state, ptend, dtime, pbuf, mgncol, mgcols, nle
    ncic_grid(:ngrdcol,top_lev:) = nc_grid(:ngrdcol,top_lev:) / &
         max(mincld,liqcldf_grid(:ngrdcol,top_lev:))
 
-   call size_dist_param_liq(mg_liq_props, icwmrst_grid(:ngrdcol,top_lev:), &
+   call size_dist_param_liq_vect(mg_liq_props, icwmrst_grid(:ngrdcol,top_lev:), &
         ncic_grid(:ngrdcol,top_lev:), rho_grid(:ngrdcol,top_lev:), &
-        mu_grid(:ngrdcol,top_lev:), lambdac_grid(:ngrdcol,top_lev:))
+        mu_grid(:ngrdcol,top_lev:), lambdac_grid(:ngrdcol,top_lev:), ngrdcol*(nlev-top_lev+1))
 
    where (icwmrst_grid(:ngrdcol,top_lev:) >= qsmall)
       rel_grid(:ngrdcol,top_lev:) = &
@@ -3205,8 +3205,8 @@ subroutine micro_mg_cam_tend_pack(state, ptend, dtime, pbuf, mgncol, mgcols, nle
    niic_grid(:ngrdcol,top_lev:) = ni_grid(:ngrdcol,top_lev:) / &
         max(mincld,icecldf_grid(:ngrdcol,top_lev:))
 
-   call size_dist_param_basic(mg_ice_props, icimrst_grid(:ngrdcol,top_lev:), &
-        niic_grid(:ngrdcol,top_lev:), rei_grid(:ngrdcol,top_lev:))
+   call size_dist_param_basic_vect(mg_ice_props, icimrst_grid(:ngrdcol,top_lev:), &
+        niic_grid(:ngrdcol,top_lev:), rei_grid(:ngrdcol,top_lev:), ngrdcol*(nlev-top_lev+1))
 
    where (icimrst_grid(:ngrdcol,top_lev:) >= qsmall)
       rei_grid(:ngrdcol,top_lev:) = 1.5_r8/rei_grid(:ngrdcol,top_lev:) &

--- a/src/physics/cam/nucleate_ice_cam.F90
+++ b/src/physics/cam/nucleate_ice_cam.F90
@@ -611,11 +611,10 @@ subroutine nucleate_ice_cam_calc( &
 
    do k = top_lev, pver
 
-      ! Get humidity and saturation vapor pressures
-      call qsat_water(t(:ncol,k), pmid(:ncol,k), &
-           es(:ncol), qs(:ncol), gam=gammas(:ncol))
-
       do i = 1, ncol
+
+         ! Get humidity and saturation vapor pressures
+         call qsat_water(t(i,k), pmid(i,k), es(i), qs(i), gam=gammas(i))
 
          relhum(i,k) = qn(i,k)/qs(i)
 

--- a/src/physics/cam/nucleate_ice_cam.F90
+++ b/src/physics/cam/nucleate_ice_cam.F90
@@ -438,9 +438,9 @@ subroutine nucleate_ice_cam_calc( &
    real(r8), allocatable :: naer2(:,:,:)    ! bulk aerosol number concentration (1/m3)
    real(r8), allocatable :: maerosol(:,:,:) ! bulk aerosol mass conc (kg/m3)
 
-   real(r8) :: qs(pcols,pver)       ! liquid-ice weighted sat mixing rat (kg/kg)
-   real(r8) :: es(pcols,pver)       ! liquid-ice weighted sat vapor press (pa)
-   real(r8) :: gammas(pcols,pver)   ! parameter for cond/evap of cloud water
+   real(r8) :: qs(pcols)            ! liquid-ice weighted sat mixing rat (kg/kg)
+   real(r8) :: es(pcols)            ! liquid-ice weighted sat vapor press (pa)
+   real(r8) :: gammas(pcols)        ! parameter for cond/evap of cloud water
    integer  :: troplev(pcols)       ! tropopause level
 
    real(r8) :: relhum(pcols,pver)  ! relative humidity
@@ -609,14 +609,13 @@ subroutine nucleate_ice_cam_calc( &
       INFreIN(:,:)  = 0.0_r8
    endif
 
-   ! Get humidity and saturation vapor pressures
-   call qsat_water(t(1:ncol,top_lev:pver), pmid(1:ncol,top_lev:pver), es(1:ncol,top_lev:pver), &
-                   qs(1:ncol,top_lev:pver), ncol, pver-top_lev+1, gam=gammas(1:ncol,top_lev:pver))
-
    do k = top_lev, pver
+      ! Get humidity and saturation vapor pressures
+      call qsat_water(t(1:ncol,k), pmid(1:ncol,k), es(1:ncol), qs(1:ncol), ncol, gam=gammas(1:ncol))
+
       do i = 1, ncol
 
-         relhum(i,k) = qn(i,k)/qs(i,k)
+         relhum(i,k) = qn(i,k)/qs(i)
 
          ! get cloud fraction, check for minimum
          icldm(i,k) = max(icecldf(i,k), mincld)

--- a/src/physics/cam/nucleate_ice_cam.F90
+++ b/src/physics/cam/nucleate_ice_cam.F90
@@ -610,11 +610,10 @@ subroutine nucleate_ice_cam_calc( &
    endif
 
    do k = top_lev, pver
+      ! Get humidity and saturation vapor pressures
+      call qsat_water(t(1:ncol,k), pmid(1:ncol,k), es(1:ncol), qs(1:ncol), ncol, gam=gammas(1:ncol))
 
       do i = 1, ncol
-
-         ! Get humidity and saturation vapor pressures
-         call qsat_water(t(i,k), pmid(i,k), es(i), qs(i), gam=gammas(i))
 
          relhum(i,k) = qn(i,k)/qs(i)
 

--- a/src/physics/cam/nucleate_ice_cam.F90
+++ b/src/physics/cam/nucleate_ice_cam.F90
@@ -438,9 +438,9 @@ subroutine nucleate_ice_cam_calc( &
    real(r8), allocatable :: naer2(:,:,:)    ! bulk aerosol number concentration (1/m3)
    real(r8), allocatable :: maerosol(:,:,:) ! bulk aerosol mass conc (kg/m3)
 
-   real(r8) :: qs(pcols)            ! liquid-ice weighted sat mixing rat (kg/kg)
-   real(r8) :: es(pcols)            ! liquid-ice weighted sat vapor press (pa)
-   real(r8) :: gammas(pcols)        ! parameter for cond/evap of cloud water
+   real(r8) :: qs(pcols,pver)       ! liquid-ice weighted sat mixing rat (kg/kg)
+   real(r8) :: es(pcols,pver)       ! liquid-ice weighted sat vapor press (pa)
+   real(r8) :: gammas(pcols,pver)   ! parameter for cond/evap of cloud water
    integer  :: troplev(pcols)       ! tropopause level
 
    real(r8) :: relhum(pcols,pver)  ! relative humidity
@@ -609,13 +609,14 @@ subroutine nucleate_ice_cam_calc( &
       INFreIN(:,:)  = 0.0_r8
    endif
 
-   do k = top_lev, pver
-      ! Get humidity and saturation vapor pressures
-      call qsat_water(t(1:ncol,k), pmid(1:ncol,k), es(1:ncol), qs(1:ncol), ncol, gam=gammas(1:ncol))
+   ! Get humidity and saturation vapor pressures
+   call qsat_water(t(1:ncol,top_lev:pver), pmid(1:ncol,top_lev:pver), es(1:ncol,top_lev:pver), &
+                   qs(1:ncol,top_lev:pver), ncol, pver-top_lev+1, gam=gammas(1:ncol,top_lev:pver))
 
+   do k = top_lev, pver
       do i = 1, ncol
 
-         relhum(i,k) = qn(i,k)/qs(i)
+         relhum(i,k) = qn(i,k)/qs(i,k)
 
          ! get cloud fraction, check for minimum
          icldm(i,k) = max(icecldf(i,k), mincld)

--- a/src/physics/cam/vertical_diffusion.F90
+++ b/src/physics/cam/vertical_diffusion.F90
@@ -1051,8 +1051,11 @@ subroutine vertical_diffusion_tend( &
           + q_tmp(:ncol,:,ixcldice)
      slv_prePBL(:ncol,:pver) = sl_prePBL(:ncol,:pver) * ( 1._r8 + zvir*qt_prePBL(:ncol,:pver) )
 
-     call qsat(state%t(:ncol,:), state%pmid(:ncol,:), &
-          tem2(:ncol,:), ftem(:ncol,:))
+     do k = 1, pver
+        do i = 1, ncol
+           call qsat(state%t(i,k), state%pmid(i,k), tem2(i,k), ftem(i,k))
+        end do
+     end do
      ftem_prePBL(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
 
      call outfld( 'qt_pre_PBL   ', qt_prePBL,                 pcols, lchnk )
@@ -1343,8 +1346,11 @@ subroutine vertical_diffusion_tend( &
      u_aft_PBL(:ncol,:pver)   =  state%u(:ncol,:pver)          + ptend%u(:ncol,:pver)            * ztodt
      v_aft_PBL(:ncol,:pver)   =  state%v(:ncol,:pver)          + ptend%v(:ncol,:pver)            * ztodt
 
-     call qsat(t_aftPBL(:ncol,:pver), state%pmid(:ncol,:pver), &
-          tem2(:ncol,:pver), ftem(:ncol,:pver))
+     do k = 1, pver
+        do i = 1, ncol
+           call qsat(t_aftPBL(i,k), state%pmid(i,k), tem2(i,k), ftem(i,k))
+        end do
+     end do
      ftem_aftPBL(:ncol,:pver) = qv_aft_PBL(:ncol,:pver) / ftem(:ncol,:pver) * 100._r8
 
      tten(:ncol,:pver)        = ( t_aftPBL(:ncol,:pver)    - state%t(:ncol,:pver) )              * rztodt

--- a/src/physics/cam/vertical_diffusion.F90
+++ b/src/physics/cam/vertical_diffusion.F90
@@ -1052,9 +1052,7 @@ subroutine vertical_diffusion_tend( &
      slv_prePBL(:ncol,:pver) = sl_prePBL(:ncol,:pver) * ( 1._r8 + zvir*qt_prePBL(:ncol,:pver) )
 
      do k = 1, pver
-        do i = 1, ncol
-           call qsat(state%t(i,k), state%pmid(i,k), tem2(i,k), ftem(i,k))
-        end do
+        call qsat(state%t(1:ncol,k), state%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
      end do
      ftem_prePBL(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
 
@@ -1347,9 +1345,7 @@ subroutine vertical_diffusion_tend( &
      v_aft_PBL(:ncol,:pver)   =  state%v(:ncol,:pver)          + ptend%v(:ncol,:pver)            * ztodt
 
      do k = 1, pver
-        do i = 1, ncol
-           call qsat(t_aftPBL(i,k), state%pmid(i,k), tem2(i,k), ftem(i,k))
-        end do
+        call qsat(t_aftPBL(1:ncol,k), state%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
      end do
      ftem_aftPBL(:ncol,:pver) = qv_aft_PBL(:ncol,:pver) / ftem(:ncol,:pver) * 100._r8
 

--- a/src/physics/cam/vertical_diffusion.F90
+++ b/src/physics/cam/vertical_diffusion.F90
@@ -1051,9 +1051,7 @@ subroutine vertical_diffusion_tend( &
           + q_tmp(:ncol,:,ixcldice)
      slv_prePBL(:ncol,:pver) = sl_prePBL(:ncol,:pver) * ( 1._r8 + zvir*qt_prePBL(:ncol,:pver) )
 
-     do k = 1, pver
-        call qsat(state%t(1:ncol,k), state%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
-     end do
+     call qsat(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), tem2(1:ncol,1:pver), ftem(1:ncol,1:pver), ncol, pver)
      ftem_prePBL(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
 
      call outfld( 'qt_pre_PBL   ', qt_prePBL,                 pcols, lchnk )
@@ -1344,9 +1342,7 @@ subroutine vertical_diffusion_tend( &
      u_aft_PBL(:ncol,:pver)   =  state%u(:ncol,:pver)          + ptend%u(:ncol,:pver)            * ztodt
      v_aft_PBL(:ncol,:pver)   =  state%v(:ncol,:pver)          + ptend%v(:ncol,:pver)            * ztodt
 
-     do k = 1, pver
-        call qsat(t_aftPBL(1:ncol,k), state%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
-     end do
+     call qsat(t_aftPBL(1:ncol,1:pver), state%pmid(1:ncol,1:pver), tem2(1:ncol,1:pver), ftem(1:ncol,1:pver), ncol, pver)
      ftem_aftPBL(:ncol,:pver) = qv_aft_PBL(:ncol,:pver) / ftem(:ncol,:pver) * 100._r8
 
      tten(:ncol,:pver)        = ( t_aftPBL(:ncol,:pver)    - state%t(:ncol,:pver) )              * rztodt

--- a/src/physics/cam/vertical_diffusion.F90
+++ b/src/physics/cam/vertical_diffusion.F90
@@ -1051,7 +1051,9 @@ subroutine vertical_diffusion_tend( &
           + q_tmp(:ncol,:,ixcldice)
      slv_prePBL(:ncol,:pver) = sl_prePBL(:ncol,:pver) * ( 1._r8 + zvir*qt_prePBL(:ncol,:pver) )
 
-     call qsat(state%t(1:ncol,1:pver), state%pmid(1:ncol,1:pver), tem2(1:ncol,1:pver), ftem(1:ncol,1:pver), ncol, pver)
+     do k = 1, pver
+        call qsat(state%t(1:ncol,k), state%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
+     end do
      ftem_prePBL(:ncol,:) = state%q(:ncol,:,1)/ftem(:ncol,:)*100._r8
 
      call outfld( 'qt_pre_PBL   ', qt_prePBL,                 pcols, lchnk )
@@ -1342,7 +1344,9 @@ subroutine vertical_diffusion_tend( &
      u_aft_PBL(:ncol,:pver)   =  state%u(:ncol,:pver)          + ptend%u(:ncol,:pver)            * ztodt
      v_aft_PBL(:ncol,:pver)   =  state%v(:ncol,:pver)          + ptend%v(:ncol,:pver)            * ztodt
 
-     call qsat(t_aftPBL(1:ncol,1:pver), state%pmid(1:ncol,1:pver), tem2(1:ncol,1:pver), ftem(1:ncol,1:pver), ncol, pver)
+     do k = 1, pver
+        call qsat(t_aftPBL(1:ncol,k), state%pmid(1:ncol,k), tem2(1:ncol,k), ftem(1:ncol,k), ncol)
+     end do
      ftem_aftPBL(:ncol,:pver) = qv_aft_PBL(:ncol,:pver) / ftem(:ncol,:pver) * 100._r8
 
      tten(:ncol,:pver)        = ( t_aftPBL(:ncol,:pver)    - state%t(:ncol,:pver) )              * rztodt

--- a/src/physics/cam/wv_sat_methods.F90
+++ b/src/physics/cam/wv_sat_methods.F90
@@ -60,16 +60,16 @@ public wv_sat_valid_idx
 public wv_sat_set_default
 public wv_sat_reset_default
 
-public wv_sat_svp_water
-public wv_sat_svp_ice
+public wv_sat_svp_water, wv_sat_svp_water_vect
+public wv_sat_svp_ice, wv_sat_svp_ice_vect
 public wv_sat_svp_trans
 
 ! pressure -> humidity conversion
-public wv_sat_svp_to_qsat
+public wv_sat_svp_to_qsat, wv_sat_svp_to_qsat_vect
 
 ! Combined qsat operations
-public wv_sat_qsat_water
-public wv_sat_qsat_ice
+public wv_sat_qsat_water, wv_sat_qsat_water_vect
+public wv_sat_qsat_ice, wv_sat_qsat_ice_vect
 public wv_sat_qsat_trans
 
 contains
@@ -192,6 +192,26 @@ elemental function wv_sat_svp_to_qsat(es, p) result(qs)
 
 end function wv_sat_svp_to_qsat
 
+! Get saturation specific humidity given pressure and SVP.
+! Specific humidity is limited to range 0-1.
+subroutine  wv_sat_svp_to_qsat_vect(es, p, qs, vlen)
+
+  integer,  intent(in) :: vlen
+  real(r8), intent(in)  :: es(vlen)  ! SVP
+  real(r8), intent(in)  :: p(vlen)   ! Current pressure.
+  real(r8), intent(out) :: qs(vlen)
+  integer :: i
+  ! If pressure is less than SVP, set qs to maximum of 1.
+  do i=1,vlen
+     if ( (p(i) - es(i)) <= 0._r8 ) then
+        qs(i) = 1.0_r8
+     else
+        qs(i) = epsilo*es(i) / (p(i) - omeps*es(i))
+     end if
+  enddo
+
+end subroutine wv_sat_svp_to_qsat_vect
+
 elemental subroutine wv_sat_qsat_water(t, p, es, qs, idx)
   !------------------------------------------------------------------!
   ! Purpose:                                                         !
@@ -217,6 +237,33 @@ elemental subroutine wv_sat_qsat_water(t, p, es, qs, idx)
 
 end subroutine wv_sat_qsat_water
 
+subroutine wv_sat_qsat_water_vect(t, p, es, qs, vlen, idx)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Calculate SVP over water at a given temperature, and then      !
+  !   calculate and return saturation specific humidity.             !
+  !------------------------------------------------------------------!
+  ! Inputs
+
+  integer,  intent(in) :: vlen
+  real(r8), intent(in) :: t(vlen)    ! Temperature
+  real(r8), intent(in) :: p(vlen)    ! Pressure
+  ! Outputs
+  real(r8), intent(out) :: es(vlen)  ! Saturation vapor pressure
+  real(r8), intent(out) :: qs(vlen)  ! Saturation specific humidity
+
+  integer,  intent(in), optional :: idx ! Scheme index
+  integer :: i
+
+  call wv_sat_svp_water_vect(t, es, vlen, idx)
+  call wv_sat_svp_to_qsat_vect(es, p, qs, vlen)
+  do i=1,vlen
+     ! Ensures returned es is consistent with limiters on qs.
+     es(i) = min(es(i), p(i))
+  enddo
+
+end subroutine wv_sat_qsat_water_vect
+
 elemental subroutine wv_sat_qsat_ice(t, p, es, qs, idx)
   !------------------------------------------------------------------!
   ! Purpose:                                                         !
@@ -241,6 +288,33 @@ elemental subroutine wv_sat_qsat_ice(t, p, es, qs, idx)
   es = min(es, p)
 
 end subroutine wv_sat_qsat_ice
+
+subroutine wv_sat_qsat_ice_vect(t, p, es, qs, vlen, idx)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Calculate SVP over ice at a given temperature, and then        !
+  !   calculate and return saturation specific humidity.             !
+  !------------------------------------------------------------------!
+  ! Inputs
+
+  integer,  intent(in) :: vlen
+  real(r8), intent(in) :: t(vlen)    ! Temperature
+  real(r8), intent(in) :: p(vlen)    ! Pressure
+  ! Outputs
+  real(r8), intent(out) :: es(vlen)  ! Saturation vapor pressure
+  real(r8), intent(out) :: qs(vlen)  ! Saturation specific humidity
+
+  integer,  intent(in), optional :: idx ! Scheme index
+  integer :: i
+
+  call wv_sat_svp_ice_vect(t, es, vlen, idx)
+  call wv_sat_svp_to_qsat_vect(es, p, qs, vlen)
+  do i=1,vlen
+     ! Ensures returned es is consistent with limiters on qs.
+     es(i) = min(es(i), p(i))
+  enddo
+
+end subroutine wv_sat_qsat_ice_vect
 
 elemental subroutine wv_sat_qsat_trans(t, p, es, qs, idx)
   !------------------------------------------------------------------!
@@ -297,6 +371,33 @@ elemental function wv_sat_svp_water(t, idx) result(es)
 
 end function wv_sat_svp_water
 
+subroutine  wv_sat_svp_water_vect(t, es, vlen, idx)
+  integer,  intent(in) :: vlen
+  real(r8), intent(in) :: t(vlen)
+  integer,  intent(in), optional :: idx
+  real(r8), intent(out) :: es(vlen)
+  integer :: i
+  integer :: use_idx
+
+  if (present(idx)) then
+     use_idx = idx
+  else
+     use_idx = default_idx
+  end if
+
+  select case (use_idx)
+  case(GoffGratch_idx)
+     call GoffGratch_svp_water_vect(t,es,vlen)
+  case(MurphyKoop_idx)
+     call MurphyKoop_svp_water_vect(t,es,vlen)
+  case(OldGoffGratch_idx)
+     call OldGoffGratch_svp_water_vect(t,es,vlen)
+  case(Bolton_idx)
+     call Bolton_svp_water_vect(t,es,vlen)
+  end select
+
+end subroutine wv_sat_svp_water_vect
+
 elemental function wv_sat_svp_ice(t, idx) result(es)
   real(r8), intent(in) :: t
   integer,  intent(in), optional :: idx
@@ -322,6 +423,34 @@ elemental function wv_sat_svp_ice(t, idx) result(es)
   end select
 
 end function wv_sat_svp_ice
+
+subroutine wv_sat_svp_ice_vect(t, es, vlen, idx)
+  integer,  intent(in) :: vlen
+  real(r8), intent(in) :: t(vlen)
+  integer,  intent(in), optional :: idx
+  real(r8), intent(out) :: es(vlen)
+  integer :: i
+
+  integer :: use_idx
+
+  if (present(idx)) then
+     use_idx = idx
+  else
+     use_idx = default_idx
+  end if
+
+  select case (use_idx)
+  case(GoffGratch_idx)
+     call GoffGratch_svp_ice_vect(t,es,vlen)
+  case(MurphyKoop_idx)
+     call MurphyKoop_svp_ice_vect(t,es,vlen)
+  case(OldGoffGratch_idx)
+     call OldGoffGratch_svp_ice_vect(t,es,vlen)
+  case(Bolton_idx)
+     call Bolton_svp_water_vect(t,es,vlen)
+  end select
+
+end subroutine wv_sat_svp_ice_vect
 
 elemental function wv_sat_svp_trans(t, idx) result (es)
 
@@ -379,6 +508,23 @@ elemental function GoffGratch_svp_water(t) result(es)
 
 end function GoffGratch_svp_water
 
+subroutine GoffGratch_svp_water_vect(t, es, vlen)
+  integer, intent(in) :: vlen
+  real(r8), intent(in)  :: t(vlen)  ! Temperature in Kelvin
+  real(r8), intent(out) :: es(vlen) ! SVP in Pa
+  integer :: i
+  ! uncertain below -70 C
+
+  do i=1,vlen
+     es(i) = 10._r8**(-7.90298_r8*(tboil/t(i)-1._r8)+ &
+       5.02808_r8*log10(tboil/t(i))- &
+       1.3816e-7_r8*(10._r8**(11.344_r8*(1._r8-t(i)/tboil))-1._r8)+ &
+       8.1328e-3_r8*(10._r8**(-3.49149_r8*(tboil/t(i)-1._r8))-1._r8)+ &
+       log10(1013.246_r8))*100._r8
+  enddo
+
+end subroutine GoffGratch_svp_water_vect
+
 elemental function GoffGratch_svp_ice(t) result(es)
   real(r8), intent(in) :: t  ! Temperature in Kelvin
   real(r8) :: es             ! SVP in Pa
@@ -389,6 +535,20 @@ elemental function GoffGratch_svp_ice(t) result(es)
        log10(6.1071_r8))*100._r8
 
 end function GoffGratch_svp_ice
+
+subroutine GoffGratch_svp_ice_vect(t, es, vlen)
+  integer, intent(in) :: vlen
+  real(r8), intent(in)  :: t(vlen)  ! Temperature in Kelvin
+  real(r8), intent(out) :: es(vlen)             ! SVP in Pa
+  integer :: i
+  ! good down to -100 C
+
+  do i=1,vlen
+     es(i) = 10._r8**(-9.09718_r8*(h2otrip/t(i)-1._r8)-3.56654_r8* &
+          log10(h2otrip/t(i))+0.876793_r8*(1._r8-t(i)/h2otrip)+ &
+          log10(6.1071_r8))*100._r8
+  enddo
+end subroutine GoffGratch_svp_ice_vect
 
 ! Murphy & Koop (2005)
 
@@ -404,6 +564,22 @@ elemental function MurphyKoop_svp_water(t) result(es)
 
 end function MurphyKoop_svp_water
 
+subroutine MurphyKoop_svp_water_vect(t, es, vlen)
+  integer, intent(in)   :: vlen
+  real(r8), intent(in)  :: t(vlen)  ! Temperature in Kelvin
+  real(r8), intent(out) :: es(vlen)             ! SVP in Pa
+  
+  integer :: i
+  ! (good for 123 < T < 332 K)
+
+  do i = 1, vlen
+     es(i) = exp(54.842763_r8 - (6763.22_r8 / t(i)) - (4.210_r8 * log(t(i))) + &
+          (0.000367_r8 * t(i)) + (tanh(0.0415_r8 * (t(i) - 218.8_r8)) * &
+          (53.878_r8 - (1331.22_r8 / t(i)) - (9.44523_r8 * log(t(i))) + &
+          0.014025_r8 * t(i))))
+  end do
+end subroutine MurphyKoop_svp_water_vect
+
 elemental function MurphyKoop_svp_ice(t) result(es)
   real(r8), intent(in) :: t  ! Temperature in Kelvin
   real(r8) :: es             ! SVP in Pa
@@ -413,6 +589,20 @@ elemental function MurphyKoop_svp_ice(t) result(es)
        - (0.00728332_r8 * t))
 
 end function MurphyKoop_svp_ice
+
+subroutine MurphyKoop_svp_ice_vect(t, es, vlen)
+  integer, intent(in)   :: vlen
+  real(r8), intent(in) :: t(vlen)  ! Temperature in Kelvin
+  real(r8), intent(out) :: es(vlen)             ! SVP in Pa
+  
+  integer :: i
+  ! (good down to 110 K)
+
+  do i = 1, vlen
+     es(i) = exp(9.550426_r8 - (5723.265_r8 / t(i)) + (3.53068_r8 * log(t(i))) &
+             - (0.00728332_r8 * t(i)))
+  end do
+end subroutine MurphyKoop_svp_ice_vect
 
 ! Old CAM implementation, also labelled Goff & Gratch (1946)
 
@@ -447,6 +637,28 @@ elemental function OldGoffGratch_svp_water(t) result(es)
   
 end function OldGoffGratch_svp_water
 
+subroutine OldGoffGratch_svp_water_vect(t,es,vlen)
+  integer, intent(in) :: vlen
+  real(r8), intent(in)  :: t(vlen)
+  real(r8), intent(out) :: es(vlen)
+
+  real(r8), dimension(vlen) :: ps, e1, e2, f1, f2, f3, f4, f5, f
+  integer :: i
+
+  do i = 1, vlen
+     ps(i) = 1013.246_r8
+     e1(i) = 11.344_r8*(1.0_r8 - t(i)/tboil)
+     e2(i) = -3.49149_r8*(tboil/t(i) - 1.0_r8)
+     f1(i) = -7.90298_r8*(tboil/t(i) - 1.0_r8)
+     f2(i) = 5.02808_r8*log10(tboil/t(i))
+     f3(i) = -1.3816_r8*(10.0_r8**e1(i) - 1.0_r8)/10000000.0_r8
+     f4(i) = 8.1328_r8*(10.0_r8**e2(i) - 1.0_r8)/1000.0_r8
+     f5(i) = log10(ps(i))
+      f(i) = f1(i) + f2(i) + f3(i) + f4(i) + f5(i)
+     es(i) = (10.0_r8**f(i))*100.0_r8
+  end do
+end subroutine OldGoffGratch_svp_water_vect
+
 elemental function OldGoffGratch_svp_ice(t) result(es)
   real(r8), intent(in) :: t
   real(r8) :: es
@@ -459,6 +671,22 @@ elemental function OldGoffGratch_svp_ice(t) result(es)
   es = 575.185606e10_r8*exp(-(term1 + term2 + term3))
   
 end function OldGoffGratch_svp_ice
+
+subroutine OldGoffGratch_svp_ice_vect(t,es,vlen)
+  integer, intent(in) :: vlen
+  real(r8), intent(in) :: t(vlen)
+  real(r8), intent(out) :: es(vlen)
+  
+  real(r8), dimension(vlen) :: term1, term2, term3
+  integer :: i
+
+  do i = 1, vlen
+     term1(i) = 2.01889049_r8/(tmelt/t(i))
+     term2(i) = 3.56654_r8*log(tmelt/t(i))
+     term3(i) = 20.947031_r8*(tmelt/t(i))
+     es(i) = 575.185606e10_r8*exp(-(term1(i) + term2(i) + term3(i)))
+  end do
+end subroutine OldGoffGratch_svp_ice_vect
 
 ! Bolton (1980)
 ! zm_conv deep convection scheme contained this SVP calculation.
@@ -480,5 +708,21 @@ elemental function Bolton_svp_water(t) result(es)
   es = c1*exp( (c2*(t - tmelt))/((t - tmelt)+c3) )
 
 end function Bolton_svp_water
+
+subroutine Bolton_svp_water_vect(t, es,vlen)
+  real(r8),parameter :: c1 = 611.2_r8
+  real(r8),parameter :: c2 = 17.67_r8
+  real(r8),parameter :: c3 = 243.5_r8
+
+  integer, intent(in)   :: vlen
+  real(r8), intent(in)  :: t(vlen)  ! Temperature in Kelvin
+  real(r8), intent(out) :: es(vlen)             ! SVP in Pa
+
+  integer :: i
+
+  do i = 1, vlen
+     es(i) = c1*exp( (c2*(t(i) - tmelt))/((t(i) - tmelt)+c3) )
+  end do
+end subroutine Bolton_svp_water_vect
 
 end module wv_sat_methods

--- a/src/physics/cam/wv_sat_methods.F90
+++ b/src/physics/cam/wv_sat_methods.F90
@@ -60,17 +60,19 @@ public wv_sat_valid_idx
 public wv_sat_set_default
 public wv_sat_reset_default
 
-public wv_sat_svp_water, wv_sat_svp_water_vect
-public wv_sat_svp_ice, wv_sat_svp_ice_vect
+public wv_sat_qsat_water, wv_sat_qsat_water_vect
+public wv_sat_qsat_ice, wv_sat_qsat_ice_vect
+
 public wv_sat_svp_trans
 
 ! pressure -> humidity conversion
 public wv_sat_svp_to_qsat, wv_sat_svp_to_qsat_vect
 
 ! Combined qsat operations
-public wv_sat_qsat_water, wv_sat_qsat_water_vect
-public wv_sat_qsat_ice, wv_sat_qsat_ice_vect
 public wv_sat_qsat_trans
+
+public wv_sat_svp_water, wv_sat_svp_water_vect
+public wv_sat_svp_ice, wv_sat_svp_ice_vect
 
 contains
 
@@ -177,11 +179,11 @@ end subroutine wv_sat_reset_default
 
 ! Get saturation specific humidity given pressure and SVP.
 ! Specific humidity is limited to range 0-1.
-elemental function wv_sat_svp_to_qsat(es, p) result(qs)
+function wv_sat_svp_to_qsat(es, p) result(qs)
 
   real(r8), intent(in) :: es  ! SVP
   real(r8), intent(in) :: p   ! Current pressure.
-  real(r8) :: qs
+  real(r8)             :: qs
 
   ! If pressure is less than SVP, set qs to maximum of 1.
   if ( (p - es) <= 0._r8 ) then
@@ -208,11 +210,11 @@ subroutine  wv_sat_svp_to_qsat_vect(es, p, qs, vlen)
      else
         qs(i) = epsilo*es(i) / (p(i) - omeps*es(i))
      end if
-  enddo
+  end do
 
 end subroutine wv_sat_svp_to_qsat_vect
 
-elemental subroutine wv_sat_qsat_water(t, p, es, qs, idx)
+subroutine wv_sat_qsat_water(t, p, es, qs, idx)
   !------------------------------------------------------------------!
   ! Purpose:                                                         !
   !   Calculate SVP over water at a given temperature, and then      !
@@ -264,7 +266,7 @@ subroutine wv_sat_qsat_water_vect(t, p, es, qs, vlen, idx)
 
 end subroutine wv_sat_qsat_water_vect
 
-elemental subroutine wv_sat_qsat_ice(t, p, es, qs, idx)
+subroutine wv_sat_qsat_ice(t, p, es, qs, idx)
   !------------------------------------------------------------------!
   ! Purpose:                                                         !
   !   Calculate SVP over ice at a given temperature, and then        !
@@ -316,7 +318,7 @@ subroutine wv_sat_qsat_ice_vect(t, p, es, qs, vlen, idx)
 
 end subroutine wv_sat_qsat_ice_vect
 
-elemental subroutine wv_sat_qsat_trans(t, p, es, qs, idx)
+subroutine wv_sat_qsat_trans(t, p, es, qs, idx)
   !------------------------------------------------------------------!
   ! Purpose:                                                         !
   !   Calculate SVP over ice at a given temperature, and then        !
@@ -345,10 +347,10 @@ end subroutine wv_sat_qsat_trans
 ! SVP INTERFACE FUNCTIONS
 !---------------------------------------------------------------------
 
-elemental function wv_sat_svp_water(t, idx) result(es)
+function wv_sat_svp_water(t, idx) result(es)
   real(r8), intent(in) :: t
   integer,  intent(in), optional :: idx
-  real(r8) :: es
+  real(r8)             :: es
 
   integer :: use_idx
 
@@ -398,10 +400,10 @@ subroutine  wv_sat_svp_water_vect(t, es, vlen, idx)
 
 end subroutine wv_sat_svp_water_vect
 
-elemental function wv_sat_svp_ice(t, idx) result(es)
-  real(r8), intent(in) :: t
+function wv_sat_svp_ice(t, idx) result(es)
+  real(r8), intent(in)  :: t
   integer,  intent(in), optional :: idx
-  real(r8) :: es
+  real(r8)              :: es
 
   integer :: use_idx
 
@@ -452,11 +454,10 @@ subroutine wv_sat_svp_ice_vect(t, es, vlen, idx)
 
 end subroutine wv_sat_svp_ice_vect
 
-elemental function wv_sat_svp_trans(t, idx) result (es)
+function wv_sat_svp_trans(t, idx) result(es)
 
   real(r8), intent(in) :: t
   integer,  intent(in), optional :: idx
-
   real(r8) :: es
 
   real(r8) :: esice      ! Saturation vapor pressure over ice

--- a/src/physics/cam/wv_saturation.F90
+++ b/src/physics/cam/wv_saturation.F90
@@ -223,7 +223,7 @@ subroutine wv_sat_init
   end if
 
   do i = 1, plenest
-    estbl(i) = svp_trans(tmin + real(i-1,r8))
+     estbl(i) = svp_trans(tmin + real(i-1,r8))
   end do
 
   if (masterproc) then
@@ -259,41 +259,41 @@ end subroutine wv_sat_final
 !---------------------------------------------------------------------
 
 ! Compute saturation vapor pressure over water
-elemental function svp_water(t) result(es)
+function svp_water(t) result(es)
 
   use wv_sat_methods, only: &
        wv_sat_svp_water
 
-  real(r8), intent(in) :: t ! Temperature (K)
-  real(r8) :: es            ! SVP (Pa)
+  real(r8), intent(in)  :: t  ! Temperature (K)
+  real(r8)              :: es ! SVP (Pa)
 
-  es = wv_sat_svp_water(T)
+  es = wv_sat_svp_water(t)
 
 end function svp_water
 
 ! Compute saturation vapor pressure over ice
-elemental function svp_ice(t) result(es)
+function svp_ice(t) result(es)
 
   use wv_sat_methods, only: &
        wv_sat_svp_ice
 
-  real(r8), intent(in) :: t ! Temperature (K)
-  real(r8) :: es            ! SVP (Pa)
+  real(r8), intent(in)  :: t  ! Temperature (K)
+  real(r8)              :: es ! SVP (Pa)
 
-  es = wv_sat_svp_ice(T)
+  es = wv_sat_svp_ice(t)
 
 end function svp_ice
 
 ! Compute saturation vapor pressure with an ice-water transition
-elemental function svp_trans(t) result(es)
+function svp_trans(t) result(es)
 
   use wv_sat_methods, only: &
        wv_sat_svp_trans
 
-  real(r8), intent(in) :: t ! Temperature (K)
-  real(r8) :: es            ! SVP (Pa)
+  real(r8), intent(in)  :: t   ! Temperature (K)
+  real(r8)              :: es  ! SVP (Pa)
 
-  es = wv_sat_svp_trans(T)
+  es = wv_sat_svp_trans(t)
 
 end function svp_trans
 
@@ -455,7 +455,7 @@ end subroutine deriv_outputs
 ! QSAT (SPECIFIC HUMIDITY) PROCEDURES
 !---------------------------------------------------------------------
 
-elemental subroutine qsat(t, p, es, qs, gam, dqsdt, enthalpy)
+subroutine qsat(t, p, es, qs, gam, dqsdt, enthalpy)
   !------------------------------------------------------------------!
   ! Purpose:                                                         !
   !   Look up and return saturation vapor pressure from precomputed  !
@@ -502,7 +502,7 @@ elemental subroutine qsat(t, p, es, qs, gam, dqsdt, enthalpy)
 
 end subroutine qsat
 
-elemental subroutine qsat_water(t, p, es, qs, gam, dqsdt, enthalpy)
+subroutine qsat_water(t, p, es, qs, gam, dqsdt, enthalpy)
   !------------------------------------------------------------------!
   ! Purpose:                                                         !
   !   Calculate SVP over water at a given temperature, and then      !
@@ -545,7 +545,7 @@ elemental subroutine qsat_water(t, p, es, qs, gam, dqsdt, enthalpy)
 
 end subroutine qsat_water
 
-elemental subroutine qsat_ice(t, p, es, qs, gam, dqsdt, enthalpy)
+subroutine qsat_ice(t, p, es, qs, gam, dqsdt, enthalpy)
   !------------------------------------------------------------------!
   ! Purpose:                                                         !
   !   Calculate SVP over ice at a given temperature, and then        !
@@ -623,10 +623,9 @@ subroutine findsp_vc(q, t, p, use_ice, tsp, qsp)
 
   n = size(q)
 
-  call findsp(q, t, p, use_ice, tsp, qsp, status)
-
   ! Currently, only 2 and 8 seem to be treated as fatal errors.
   do i = 1,n
+     call findsp(q(i), t(i), p(i), use_ice, tsp(i), qsp(i), status(i))
      if (status(i) == 2) then
         write(iulog,*) ' findsp not converging at i = ', i
         write(iulog,*) ' t, q, p ', t(i), q(i), p(i)
@@ -642,7 +641,7 @@ subroutine findsp_vc(q, t, p, use_ice, tsp, qsp)
 
 end subroutine findsp_vc
 
-elemental subroutine findsp (q, t, p, use_ice, tsp, qsp, status)
+subroutine findsp (q, t, p, use_ice, tsp, qsp, status)
 !----------------------------------------------------------------------- 
 ! 
 ! Purpose: 

--- a/src/physics/cam/wv_saturation.F90
+++ b/src/physics/cam/wv_saturation.F90
@@ -47,8 +47,8 @@ public wv_sat_init
 public wv_sat_final
 
 ! Saturation vapor pressure calculations
-public svp_water
-public svp_ice
+public svp_water, svp_water_vect
+public svp_ice, svp_ice_vect
   
 ! Mixed phase (water + ice) saturation vapor pressure table lookup
 public estblf
@@ -284,6 +284,20 @@ function svp_water(t) result(es)
 
 end function svp_water
 
+! Compute saturation vapor pressure over water
+subroutine svp_water_vect(t, es, vlen)
+
+  use wv_sat_methods, only: &
+       wv_sat_svp_water_vect
+
+  integer,  intent(in)  :: vlen
+  real(r8), intent(in)  :: t(vlen)  ! Temperature (K)
+  real(r8), intent(out) :: es(vlen) ! SVP (Pa)
+
+  call wv_sat_svp_water_vect(t, es, vlen)
+
+end subroutine svp_water_vect
+
 ! Compute saturation vapor pressure over ice
 function svp_ice(t) result(es)
 
@@ -297,6 +311,20 @@ function svp_ice(t) result(es)
 
 end function svp_ice
 
+! Compute saturation vapor pressure over ice
+subroutine svp_ice_vect(t, es, vlen)
+
+  use wv_sat_methods, only: &
+       wv_sat_svp_ice_vect
+
+  integer,  intent(in)  :: vlen
+  real(r8), intent(in)  :: t(vlen)  ! Temperature (K)
+  real(r8), intent(out) :: es(vlen) ! SVP (Pa)
+
+  call wv_sat_svp_ice_vect(t, es, vlen)
+
+end subroutine svp_ice_vect
+
 ! Compute saturation vapor pressure with an ice-water transition
 function svp_trans(t) result(es)
 
@@ -309,6 +337,20 @@ function svp_trans(t) result(es)
   es = wv_sat_svp_trans(t)
 
 end function svp_trans
+
+! Compute saturation vapor pressure with an ice-water transition
+subroutine svp_trans_vect(t, es, vlen)
+
+  use wv_sat_methods, only: &
+       wv_sat_svp_trans_vect
+
+  integer,  intent(in)  :: vlen
+  real(r8), intent(in)  :: t(vlen)   ! Temperature (K)
+  real(r8), intent(out) :: es(vlen)  ! SVP (Pa)
+
+  call wv_sat_svp_trans_vect(t, es, vlen)
+
+end subroutine svp_trans_vect
 
 !---------------------------------------------------------------------
 ! UTILITIES

--- a/src/physics/cam/wv_saturation.F90
+++ b/src/physics/cam/wv_saturation.F90
@@ -33,7 +33,8 @@ use physconst,    only: epsilo, &
                         h2otrip
 
 use wv_sat_methods, only: &
-     svp_to_qsat => wv_sat_svp_to_qsat
+     svp_to_qsat => wv_sat_svp_to_qsat, &
+     svp_to_qsat_vect => wv_sat_svp_to_qsat_vect
 
 implicit none
 private
@@ -56,8 +57,20 @@ public svp_to_qsat
 
 ! Subroutines that return both SVP and humidity
 ! Optional arguments do temperature derivatives
+interface qsat
+  module procedure qsat_line
+  module procedure qsat_vect
+end interface
 public qsat           ! Mixed phase
+interface qsat_water
+  module procedure qsat_water_line
+  module procedure qsat_water_vect
+end interface
 public qsat_water     ! SVP over water only
+interface qsat_ice
+  module procedure qsat_ice_line
+  module procedure qsat_ice_vect
+end interface
 public qsat_ice       ! SVP over ice only
 
 ! Wet bulb temperature solver
@@ -320,6 +333,29 @@ elemental function estblf(t) result(es)
 
 end function estblf
 
+! Does linear interpolation from nearest values found
+! in the table (estbl).
+subroutine estblf_vect(t, es, vlen)
+
+  integer,                   intent(in)  :: vlen
+  real(r8), dimension(vlen), intent(in)  :: t     ! Temperature 
+  real(r8), dimension(vlen), intent(out) :: es    ! SVP (Pa)
+
+  integer  :: i         ! Index for t in the table
+  integer  :: j
+  real(r8) :: t_tmp     ! intermediate temperature for es look-up
+
+  real(r8) :: weight ! Weight for interpolation
+
+  do j = 1, vlen
+     t_tmp = max(min(t(j),tmax)-tmin, 0._r8)   ! Number of table entries above tmin
+     i = int(t_tmp) + 1                     ! Corresponding index.
+     weight = t_tmp - aint(t_tmp, r8)       ! Fractional part of t_tmp (for interpolation).
+     es(j) = (1._r8 - weight)*estbl(i) + weight*estbl(i+1)
+  end do
+
+end subroutine estblf_vect
+
 ! Get enthalpy based only on temperature
 ! and specific humidity.
 elemental function tq_enthalpy(t, q, hltalt) result(enthalpy)
@@ -333,6 +369,24 @@ elemental function tq_enthalpy(t, q, hltalt) result(enthalpy)
   enthalpy = cpair * t + hltalt * q
   
 end function tq_enthalpy
+
+! Get enthalpy based only on temperature
+! and specific humidity.
+subroutine tq_enthalpy_vect(t, q, hltalt, enthalpy, vlen)
+  
+  integer,                   intent(in)  :: vlen
+  real(r8), dimension(vlen), intent(in)  :: t      ! Temperature
+  real(r8), dimension(vlen), intent(in)  :: q      ! Specific humidity
+  real(r8), dimension(vlen), intent(in)  :: hltalt ! Modified hlat for T derivatives
+
+  real(r8), dimension(vlen), intent(out) :: enthalpy
+
+  integer :: i
+
+  do i = 1, vlen
+     enthalpy(i) = cpair * t(i) + hltalt(i) * q(i)
+  end do
+end subroutine tq_enthalpy_vect
 
 !---------------------------------------------------------------------
 ! LATENT HEAT OF VAPORIZATION CORRECTIONS
@@ -359,6 +413,32 @@ elemental subroutine no_ip_hltalt(t, hltalt)
   end if
 
 end subroutine no_ip_hltalt
+
+subroutine no_ip_hltalt_vect(t, hltalt, vlen)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Calculate latent heat of vaporization of pure liquid water at  !
+  !   a given temperature.                                           !
+  !------------------------------------------------------------------!
+
+  ! Inputs
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t        ! Temperature
+  ! Outputs
+  real(r8), dimension(vlen), intent(out) :: hltalt  ! Appropriately modified hlat
+ 
+  integer :: i
+
+  do i = 1, vlen
+     hltalt(i) = latvap  
+     ! Account for change of latvap with t above freezing where
+     ! constant slope is given by -2369 j/(kg c) = cpv - cw
+     if (t(i) >= tmelt) then
+        hltalt(i) = hltalt(i) - 2369.0_r8*(t(i)-tmelt)
+     end if
+  end do
+
+end subroutine no_ip_hltalt_vect
 
 elemental subroutine calc_hltalt(t, hltalt, tterm)
   !------------------------------------------------------------------!
@@ -414,12 +494,77 @@ elemental subroutine calc_hltalt(t, hltalt, tterm)
 
 end subroutine calc_hltalt
 
+subroutine calc_hltalt_vect(t, hltalt, vlen, tterm)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Calculate latent heat of vaporization of water at a given      !
+  !   temperature, taking into account the ice phase if temperature  !
+  !   is below freezing.                                             !
+  !   Optional argument also calculates a term used to calculate     !
+  !   d(es)/dT within the water-ice transition range.                !
+  !------------------------------------------------------------------!
+
+  ! Inputs
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t        ! Temperature
+  ! Outputs
+  real(r8), dimension(vlen), intent(out) :: hltalt  ! Appropriately modified hlat
+  ! Term to account for d(es)/dT in transition region.
+  real(r8), dimension(vlen), intent(out), optional :: tterm
+
+  ! Local variables
+  real(r8) :: tc      ! Temperature in degrees C
+  real(r8) :: weight  ! Weight for es transition from water to ice
+  logical  :: present_tterm
+  ! Loop iterator
+  integer :: i, j
+  
+  present_tterm = present(tterm)
+
+  if (present_tterm) then
+     do i = 1, vlen
+        tterm(i) = 0.0_r8
+     end do
+  end if
+
+  call no_ip_hltalt_vect(t,hltalt,vlen)
+
+  do j = 1, vlen
+     if (t(i) < tmelt) then
+        ! Weighting of hlat accounts for transition from water to ice.
+        tc = t(i) - tmelt
+   
+        if (tc >= -ttrice) then
+           weight = -tc/ttrice
+   
+           ! polynomial expression approximates difference between es
+           ! over water and es over ice from 0 to -ttrice (C) (max of
+           ! ttrice is 40): required for accurate estimate of es
+           ! derivative in transition range from ice to water
+           if (present_tterm) then
+              do i = size(pcf), 1, -1
+                 tterm(j) = pcf(i) + tc*tterm(j)
+              end do
+              tterm(j) = tterm(j)/ttrice
+           end if
+   
+        else
+           weight = 1.0_r8
+        end if
+   
+        hltalt(j) = hltalt(j) + weight*latice
+   
+     end if
+  end do
+
+end subroutine calc_hltalt_vect
+
 !---------------------------------------------------------------------
 ! OPTIONAL OUTPUTS
 !---------------------------------------------------------------------
 
 ! Temperature derivative outputs, for qsat_*
-elemental subroutine deriv_outputs(t, p, es, qs, hltalt, tterm, &
+subroutine deriv_outputs_line(t, p, es, qs, hltalt, tterm, &
      gam, dqsdt)
 
   ! Inputs
@@ -449,13 +594,54 @@ elemental subroutine deriv_outputs(t, p, es, qs, hltalt, tterm, &
   if (present(dqsdt)) dqsdt = dqsdt_loc
   if (present(gam))   gam   = dqsdt_loc * (hltalt/cpair)
 
-end subroutine deriv_outputs
+end subroutine deriv_outputs_line
+
+! Temperature derivative outputs, for qsat_*
+subroutine deriv_outputs_vect(t, p, es, qs, hltalt, tterm, vlen, &
+     gam, dqsdt)
+
+  ! Inputs
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t      ! Temperature
+  real(r8), dimension(vlen), intent(in) :: p      ! Pressure
+  real(r8), dimension(vlen), intent(in) :: es     ! Saturation vapor pressure
+  real(r8), dimension(vlen), intent(in) :: qs     ! Saturation specific humidity
+  real(r8), dimension(vlen), intent(in) :: hltalt ! Modified latent heat
+  real(r8), dimension(vlen), intent(in) :: tterm  ! Extra term for d(es)/dT in
+                                 ! transition region.
+
+  ! Outputs
+  real(r8), dimension(vlen), intent(out), optional :: gam      ! (hltalt/cpair)*(d(qs)/dt)
+  real(r8), dimension(vlen), intent(out), optional :: dqsdt    ! (d(qs)/dt)
+
+  ! Local variables
+  real(r8) :: desdt        ! d(es)/dt
+  real(r8) :: dqsdt_loc    ! local copy of dqsdt
+  logical  :: present_dqsdt, present_gam
+  integer  :: i
+
+  present_dqsdt = present(dqsdt)
+  present_gam   = present(gam)
+  
+  do i = 1, vlen
+     if (qs(i) == 1.0_r8) then
+        dqsdt_loc = 0._r8
+     else
+        desdt = hltalt(i)*es(i)/(rh2o*t(i)*t(i)) + tterm(i)
+        dqsdt_loc = qs(i)*p(i)*desdt/(es(i)*(p(i)-omeps*es(i)))
+     end if
+   
+     if (present_dqsdt) dqsdt(i) = dqsdt_loc
+     if (present_gam)   gam(i)   = dqsdt_loc * (hltalt(i)/cpair)
+  end do
+
+end subroutine deriv_outputs_vect
 
 !---------------------------------------------------------------------
 ! QSAT (SPECIFIC HUMIDITY) PROCEDURES
 !---------------------------------------------------------------------
 
-subroutine qsat(t, p, es, qs, gam, dqsdt, enthalpy)
+subroutine qsat_line(t, p, es, qs, gam, dqsdt, enthalpy)
   !------------------------------------------------------------------!
   ! Purpose:                                                         !
   !   Look up and return saturation vapor pressure from precomputed  !
@@ -495,14 +681,65 @@ subroutine qsat(t, p, es, qs, gam, dqsdt, enthalpy)
 
      if (present(enthalpy)) enthalpy = tq_enthalpy(t, qs, hltalt)
 
-     call deriv_outputs(t, p, es, qs, hltalt, tterm, &
+     call deriv_outputs_line(t, p, es, qs, hltalt, tterm, &
           gam=gam, dqsdt=dqsdt)
 
   end if
 
-end subroutine qsat
+end subroutine qsat_line
 
-subroutine qsat_water(t, p, es, qs, gam, dqsdt, enthalpy)
+subroutine qsat_vect(t, p, es, qs, vlen, gam, dqsdt, enthalpy)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Look up and return saturation vapor pressure from precomputed  !
+  !   table, then calculate and return saturation specific humidity. !
+  !   Optionally return various temperature derivatives or enthalpy  !
+  !   at saturation.                                                 !
+  !------------------------------------------------------------------!
+
+  ! Inputs
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t    ! Temperature
+  real(r8), dimension(vlen), intent(in) :: p    ! Pressure
+  ! Outputs
+  real(r8), dimension(vlen), intent(out) :: es  ! Saturation vapor pressure
+  real(r8), dimension(vlen), intent(out) :: qs  ! Saturation specific humidity
+
+  real(r8), dimension(vlen), intent(out), optional :: gam    ! (l/cpair)*(d(qs)/dt)
+  real(r8), dimension(vlen), intent(out), optional :: dqsdt  ! (d(qs)/dt)
+  real(r8), dimension(vlen), intent(out), optional :: enthalpy ! cpair*t + hltalt*q
+
+  ! Local variables
+  real(r8), dimension(vlen) :: hltalt       ! Modified latent heat for T derivatives
+  real(r8), dimension(vlen) :: tterm        ! Account for d(es)/dT in transition region
+  integer                   :: i
+
+  call estblf_vect(t, es, vlen)
+
+  call svp_to_qsat_vect(es, p, qs, vlen)
+
+  ! Ensures returned es is consistent with limiters on qs.
+  do i = 1, vlen
+     es(i) = min(es(i), p(i))
+  end do
+
+  ! Calculate optional arguments.
+  if (present(gam) .or. present(dqsdt) .or. present(enthalpy)) then
+
+     ! "generalized" analytic expression for t derivative of es
+     ! accurate to within 1 percent for 173.16 < t < 373.16
+     call calc_hltalt_vect(t, hltalt, vlen, tterm)
+
+     if (present(enthalpy)) call tq_enthalpy_vect(t, qs, hltalt, enthalpy, vlen)
+
+     call deriv_outputs_vect(t, p, es, qs, hltalt, tterm, vlen, &
+          gam=gam, dqsdt=dqsdt)
+
+  end if
+
+end subroutine qsat_vect
+
+subroutine qsat_water_line(t, p, es, qs, gam, dqsdt, enthalpy)
   !------------------------------------------------------------------!
   ! Purpose:                                                         !
   !   Calculate SVP over water at a given temperature, and then      !
@@ -538,14 +775,64 @@ subroutine qsat_water(t, p, es, qs, gam, dqsdt, enthalpy)
      if (present(enthalpy)) enthalpy = tq_enthalpy(t, qs, hltalt)
 
      ! For pure water/ice transition term is 0.
-     call deriv_outputs(t, p, es, qs, hltalt, 0._r8, &
+     call deriv_outputs_line(t, p, es, qs, hltalt, 0._r8, &
           gam=gam, dqsdt=dqsdt)
 
   end if
 
-end subroutine qsat_water
+end subroutine qsat_water_line
 
-subroutine qsat_ice(t, p, es, qs, gam, dqsdt, enthalpy)
+subroutine qsat_water_vect(t, p, es, qs, vlen, gam, dqsdt, enthalpy)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Calculate SVP over water at a given temperature, and then      !
+  !   calculate and return saturation specific humidity.             !
+  !   Optionally return various temperature derivatives or enthalpy  !
+  !   at saturation.                                                 !
+  !------------------------------------------------------------------!
+
+  use wv_sat_methods, only: wv_sat_qsat_water_vect
+
+  ! Inputs
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t    ! Temperature
+  real(r8), dimension(vlen), intent(in) :: p    ! Pressure
+  ! Outputs
+  real(r8), dimension(vlen), intent(out) :: es  ! Saturation vapor pressure
+  real(r8), dimension(vlen), intent(out) :: qs  ! Saturation specific humidity
+
+  real(r8), dimension(vlen), intent(out), optional :: gam    ! (l/cpair)*(d(qs)/dt)
+  real(r8), dimension(vlen), intent(out), optional :: dqsdt  ! (d(qs)/dt)
+  real(r8), dimension(vlen), intent(out), optional :: enthalpy ! cpair*t + hltalt*q
+
+  ! Local variables
+  real(r8), dimension(vlen) :: hltalt       ! Modified latent heat for T derivatives
+  real(r8), dimension(vlen) :: tterm
+  integer                   :: i
+
+  do i = 1, vlen
+     tterm(i) = 0._r8
+  end do
+
+  call wv_sat_qsat_water_vect(t, p, es, qs, vlen)
+
+  if (present(gam) .or. present(dqsdt) .or. present(enthalpy)) then
+
+     ! "generalized" analytic expression for t derivative of es
+     ! accurate to within 1 percent for 173.16 < t < 373.16
+     call no_ip_hltalt_vect(t, hltalt, vlen)
+
+     if (present(enthalpy)) call tq_enthalpy_vect(t, qs, hltalt, enthalpy, vlen)
+
+     ! For pure water/ice transition term is 0.
+     call deriv_outputs_vect(t, p, es, qs, hltalt, tterm, vlen, &
+          gam=gam, dqsdt=dqsdt)
+
+  end if
+
+end subroutine qsat_water_vect
+
+subroutine qsat_ice_line(t, p, es, qs, gam, dqsdt, enthalpy)
   !------------------------------------------------------------------!
   ! Purpose:                                                         !
   !   Calculate SVP over ice at a given temperature, and then        !
@@ -580,12 +867,63 @@ subroutine qsat_ice(t, p, es, qs, gam, dqsdt, enthalpy)
      if (present(enthalpy)) enthalpy = tq_enthalpy(t, qs, hltalt)
 
      ! For pure water/ice transition term is 0.
-     call deriv_outputs(t, p, es, qs, hltalt, 0._r8, &
+     call deriv_outputs_line(t, p, es, qs, hltalt, 0._r8, &
           gam=gam, dqsdt=dqsdt)
 
   end if
 
-end subroutine qsat_ice
+end subroutine qsat_ice_line
+
+subroutine qsat_ice_vect(t, p, es, qs, vlen, gam, dqsdt, enthalpy)
+  !------------------------------------------------------------------!
+  ! Purpose:                                                         !
+  !   Calculate SVP over ice at a given temperature, and then        !
+  !   calculate and return saturation specific humidity.             !
+  !   Optionally return various temperature derivatives or enthalpy  !
+  !   at saturation.                                                 !
+  !------------------------------------------------------------------!
+
+  use wv_sat_methods, only: wv_sat_qsat_ice_vect
+
+  ! Inputs
+  integer,                   intent(in) :: vlen
+  real(r8), dimension(vlen), intent(in) :: t    ! Temperature
+  real(r8), dimension(vlen), intent(in) :: p    ! Pressure
+  ! Outputs
+  real(r8), dimension(vlen), intent(out) :: es  ! Saturation vapor pressure
+  real(r8), dimension(vlen), intent(out) :: qs  ! Saturation specific humidity
+
+  real(r8), dimension(vlen), intent(out), optional :: gam    ! (l/cpair)*(d(qs)/dt)
+  real(r8), dimension(vlen), intent(out), optional :: dqsdt  ! (d(qs)/dt)
+  real(r8), dimension(vlen), intent(out), optional :: enthalpy ! cpair*t + hltalt*q
+
+  ! Local variables
+  real(r8), dimension(vlen) :: hltalt       ! Modified latent heat for T derivatives
+  real(r8), dimension(vlen) :: tterm
+  integer                   :: i
+
+  do i = 1, vlen
+     tterm(i) = 0._r8
+  end do
+
+  call wv_sat_qsat_ice_vect(t, p, es, qs, vlen)
+
+  if (present(gam) .or. present(dqsdt) .or. present(enthalpy)) then
+
+     do i = 1, vlen
+        ! For pure ice, just add latent heats.
+        hltalt(i) = latvap + latice
+     end do
+
+     if (present(enthalpy)) call tq_enthalpy_vect(t, qs, hltalt, enthalpy, vlen)
+
+     ! For pure water/ice transition term is 0.
+     call deriv_outputs_vect(t, p, es, qs, hltalt, tterm, vlen, &
+          gam=gam, dqsdt=dqsdt)
+
+  end if
+
+end subroutine qsat_ice_vect
 
 !---------------------------------------------------------------------
 ! FINDSP (WET BULB TEMPERATURE) PROCEDURES

--- a/src/physics/cam/zm_conv.F90
+++ b/src/physics/cam/zm_conv.F90
@@ -1481,9 +1481,11 @@ subroutine zm_conv_evap(ncol,lchnk, &
     prec(:ncol) = prec(:ncol)*1000._r8
 
 ! determine saturation vapor pressure
-    call qsat(t(1:ncol, 1:pver), pmid(1:ncol, 1:pver), &
-         es(1:ncol, 1:pver), qs(1:ncol, 1:pver))
-
+    do k = 1,pver
+       do i = 1,ncol
+          call qsat(t(i,k), pmid(i,k), es(i,k), qs(i,k))
+       end do
+    end do
 ! determine ice fraction in rain production (use cloud water parameterization fraction at present)
     call cldfrc_fice(ncol, t, fice, fsnow_conv)
 
@@ -4702,7 +4704,7 @@ end SUBROUTINE ientropy
 ! Wrapper for qsat_water that does translation between Pa and hPa
 ! qsat_water uses Pa internally, so get it right, need to pass in Pa.
 ! Afterward, set es back to hPa.
-elemental subroutine qsat_hPa(t, p, es, qm)
+subroutine qsat_hPa(t, p, es, qm)
   use wv_saturation, only: qsat_water
 
   ! Inputs

--- a/src/physics/cam/zm_conv.F90
+++ b/src/physics/cam/zm_conv.F90
@@ -1481,7 +1481,9 @@ subroutine zm_conv_evap(ncol,lchnk, &
     prec(:ncol) = prec(:ncol)*1000._r8
 
 ! determine saturation vapor pressure
-    call qsat(t(1:ncol,1:pver), pmid(1:ncol,1:pver), es(1:ncol,1:pver), qs(1:ncol,1:pver), ncol, pver)
+    do k = 1,pver
+       call qsat(t(1:ncol,k), pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
+    end do
 ! determine ice fraction in rain production (use cloud water parameterization fraction at present)
     call cldfrc_fice(ncol, t, fice, fsnow_conv)
 

--- a/src/physics/cam/zm_conv.F90
+++ b/src/physics/cam/zm_conv.F90
@@ -1482,9 +1482,7 @@ subroutine zm_conv_evap(ncol,lchnk, &
 
 ! determine saturation vapor pressure
     do k = 1,pver
-       do i = 1,ncol
-          call qsat(t(i,k), pmid(i,k), es(i,k), qs(i,k))
-       end do
+       call qsat(t(1:ncol,k), pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
     end do
 ! determine ice fraction in rain production (use cloud water parameterization fraction at present)
     call cldfrc_fice(ncol, t, fice, fsnow_conv)

--- a/src/physics/cam/zm_conv.F90
+++ b/src/physics/cam/zm_conv.F90
@@ -1481,9 +1481,7 @@ subroutine zm_conv_evap(ncol,lchnk, &
     prec(:ncol) = prec(:ncol)*1000._r8
 
 ! determine saturation vapor pressure
-    do k = 1,pver
-       call qsat(t(1:ncol,k), pmid(1:ncol,k), es(1:ncol,k), qs(1:ncol,k), ncol)
-    end do
+    call qsat(t(1:ncol,1:pver), pmid(1:ncol,1:pver), es(1:ncol,1:pver), qs(1:ncol,1:pver), ncol, pver)
 ! determine ice fraction in rain production (use cloud water parameterization fraction at present)
     call cldfrc_fice(ncol, t, fice, fsnow_conv)
 

--- a/src/physics/cam/zm_microphysics.F90
+++ b/src/physics/cam/zm_microphysics.F90
@@ -18,7 +18,7 @@ use ndrop_bam,         only: ndrop_bam_run
 use nucleate_ice,      only: nucleati
 use shr_spfn_mod,     only: erf => shr_spfn_erf 
 use shr_spfn_mod,     only: gamma => shr_spfn_gamma
-use wv_saturation,  only: svp_water, svp_ice
+use wv_saturation,  only: svp_water_vect, svp_ice_vect
 use cam_logfile,       only: iulog
 use cam_abortutils,        only: endrun
 use micro_mg_utils, only:ice_autoconversion, snow_self_aggregation, accrete_cloud_water_snow, &
@@ -829,6 +829,9 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
      end do
   end do
 
+  call svp_water_vect(t(1:il2g,1:pver), es(1:il2g,1:pver), il2g*pver)     ! over water in mixed clouds
+  call svp_ice_vect(t(1:il2g,1:pver), esi(1:il2g,1:pver), il2g*pver)      ! over ice
+
   ! skip microphysical calculations if no cloud water
   do i=1,il2g
      if (ltrue(i).eq.0) then
@@ -1520,8 +1523,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
               !..............................................................................
               !ice nucleation
-              es(i,k)  = svp_water(t(i,k))     ! over water in mixed clouds
-              esi(i,k) = svp_ice(t(i,k))     ! over ice
               qs(i,k) = 0.622_r8*es(i,k)/(ph(i,k) - (1.0_r8-0.622_r8)*es(i,k))
               qs(i,k) = min(1.0_r8,qs(i,k))
               if (qs(i,k) < 0.0_r8)  qs(i,k) = 1.0_r8

--- a/src/physics/cam/zm_microphysics.F90
+++ b/src/physics/cam/zm_microphysics.F90
@@ -829,9 +829,6 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
      end do
   end do
 
-  call svp_water_vect(t(1:il2g,1:pver), es(1:il2g,1:pver), il2g*pver)     ! over water in mixed clouds
-  call svp_ice_vect(t(1:il2g,1:pver), esi(1:il2g,1:pver), il2g*pver)      ! over ice
-
   ! skip microphysical calculations if no cloud water
   do i=1,il2g
      if (ltrue(i).eq.0) then
@@ -950,6 +947,9 @@ subroutine zm_mphy(su,    qu,   mu,   du,   eu,    cmel,  cmei,  zf,   pm,   te,
 
            fhmrm (i,k) = 0._r8
         end do
+
+        call svp_water_vect(t(i,msg+2:pver), es(i,msg+2:pver), pver-msg+1)     ! over water in mixed clouds
+        call svp_ice_vect(t(i,msg+2:pver), esi(i,msg+2:pver), pver-msg+1)      ! over ice
 
         do k = pver,msg+2,-1
   


### PR DESCRIPTION
We introduce some changes to CAM codes to (1) save some computational cost and (2) make the codes portable to GPU, based on John Dennis's previous work on MG2.
- The computational cost is saved mainly due to the elimination of **pure/elemental** key words for the vapor saturation related subroutines (e.g., subroutines with name **qsat**) and using the vectorized subroutines. The major changes occur in the **wv_sat_methods.F90** and **wv_saturation.F90**, but many codes under the **physics/cam** and **chemistry** folders are also changed to accommodate the new interfaces of subroutines.
- In addition, we explicitly specify the loop index when we call the vapor saturation subroutines, which is necessary to get the code ready to be ported to GPU.
- We also make some format changes (e.g., add space) to make the coding style more consistent but this is optional.

All these changes are done based on the commit **208866b** of `cam_development` branch. We perform the following ERP test to confirm that all our changes are **BFB**.

Test suite: ERP_Ln9
Test baseline: 9-time-step CAM simulation using commit **208866b** of `cam_development` branch, making sure the tag **pumas_cam-release_v1.9** is used to check out the PUMAS Repo.
Test status: [BFB]